### PR TITLE
change CalcViewModel into a WindowsRuntimeComponent project

### DIFF
--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -35,58 +35,58 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{90e9761d-9262-4773-942d-caeae75d7140}</ProjectGuid>
-    <Keyword>StaticLibrary</Keyword>
-    <RootNamespace>CalcViewModel</RootNamespace>
+    <ProjectGuid>{812d1a7b-b8ac-49e4-8e6d-af5d59500d56}</ProjectGuid>
+    <Keyword>WindowsRuntimeComponent</Keyword>
+    <RootNamespace>CalculatorApp</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <PlatformToolset>v142</PlatformToolset>
@@ -105,13 +105,13 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -122,169 +122,165 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <GenerateManifest>false</GenerateManifest>
-    <GenerateProjectSpecificOutputFolder>true</GenerateProjectSpecificOutputFolder>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <PreprocessorDefinitions>_WINRT_DLL;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalOptions>/bigobj /await %(AdditionalOptions)</AdditionalOptions>
+      <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
     </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-    </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
-    <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsWinRT>true</CompileAsWinRT>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <WarningLevel>Level4</WarningLevel>
-      <TreatWarningAsError>true</TreatWarningAsError>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
-      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
-    </Link>
-    <Lib>
-      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
-    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(IsStoreBuild)' == 'True'">
     <ClCompile>
@@ -314,6 +310,7 @@
     <ClInclude Include="Common\NavCategory.h" />
     <ClInclude Include="Common\NetworkManager.h" />
     <ClInclude Include="Common\NumberBase.h" />
+    <ClInclude Include="Common\RadixType.h" />
     <ClInclude Include="Common\TraceLogger.h" />
     <ClInclude Include="Common\Utils.h" />
     <ClInclude Include="DataLoaders\CurrencyDataLoader.h" />
@@ -350,6 +347,7 @@
     <ClCompile Include="Common\LocalizationService.cpp" />
     <ClCompile Include="Common\NavCategory.cpp" />
     <ClCompile Include="Common\NetworkManager.cpp" />
+    <ClCompile Include="Common\RadixType.cpp" />
     <ClCompile Include="Common\TraceLogger.cpp" />
     <ClCompile Include="Common\Utils.cpp" />
     <ClCompile Include="DataLoaders\CurrencyDataLoader.cpp" />
@@ -365,10 +363,10 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
@@ -389,6 +387,7 @@
   <ItemDefinitionGroup Condition="!Exists('DataLoaders\DataLoaderConstants.h')">
     <ClCompile>
       <AdditionalOptions>/DUSE_MOCK_DATA %(AdditionalOptions)</AdditionalOptions>
+      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <Choose>
@@ -407,5 +406,6 @@
     <None Include="DataLoaders\DefaultFromToCurrency.json" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
 </Project>

--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -43,7 +43,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/CalcViewModel/CalcViewModel.vcxproj.filters
+++ b/src/CalcViewModel/CalcViewModel.vcxproj.filters
@@ -1,28 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <Filter Include="Resources">
+      <UniqueIdentifier>5f4c8558-c780-41a5-b937-f9d79ad434a0</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
     <Filter Include="Common">
-      <UniqueIdentifier>{1daab7c4-63f6-4266-a259-f34acad66d09}</UniqueIdentifier>
+      <UniqueIdentifier>{05fb7833-4679-4430-bf21-808354e815bf}</UniqueIdentifier>
     </Filter>
     <Filter Include="Common\Automation">
-      <UniqueIdentifier>{8d4edf06-c312-4312-978a-b6c2beb8295a}</UniqueIdentifier>
+      <UniqueIdentifier>{8f1ef587-e5ce-4fc2-b9b7-73326d5e779a}</UniqueIdentifier>
     </Filter>
     <Filter Include="DataLoaders">
-      <UniqueIdentifier>{0184f727-b8aa-4af8-a699-63f1b56e7853}</UniqueIdentifier>
+      <UniqueIdentifier>{70216695-3d7b-451a-98e4-cacbea3ba0a6}</UniqueIdentifier>
     </Filter>
     <Filter Include="GraphingCalculator">
-      <UniqueIdentifier>{cf7dca32-9727-4f98-83c3-1c0ca7dd1e0c}</UniqueIdentifier>
+      <UniqueIdentifier>{9b94309f-6b9b-4cbb-8584-4273061cc432}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
-    <ClCompile Include="ApplicationViewModel.cpp" />
-    <ClCompile Include="DateCalculatorViewModel.cpp" />
-    <ClCompile Include="HistoryItemViewModel.cpp" />
-    <ClCompile Include="HistoryViewModel.cpp" />
-    <ClCompile Include="MemoryItemViewModel.cpp" />
-    <ClCompile Include="StandardCalculatorViewModel.cpp" />
-    <ClCompile Include="UnitConverterViewModel.cpp" />
     <ClCompile Include="Common\AppResourceProvider.cpp">
       <Filter>Common</Filter>
     </ClCompile>
@@ -56,11 +53,17 @@
     <ClCompile Include="Common\NetworkManager.cpp">
       <Filter>Common</Filter>
     </ClCompile>
+    <ClCompile Include="Common\RadixType.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
     <ClCompile Include="Common\TraceLogger.cpp">
       <Filter>Common</Filter>
     </ClCompile>
     <ClCompile Include="Common\Utils.cpp">
       <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="Common\Automation\NarratorAnnouncement.cpp">
+      <Filter>Common\Automation</Filter>
     </ClCompile>
     <ClCompile Include="Common\Automation\NarratorNotifier.cpp">
       <Filter>Common\Automation</Filter>
@@ -80,24 +83,23 @@
     <ClCompile Include="GraphingCalculator\GraphingCalculatorViewModel.cpp">
       <Filter>GraphingCalculator</Filter>
     </ClCompile>
-    <ClCompile Include="Common\Automation\NarratorAnnouncement.cpp">
-      <Filter>Common\Automation</Filter>
-    </ClCompile>
     <ClCompile Include="GraphingCalculator\GraphingSettingsViewModel.cpp">
       <Filter>GraphingCalculator</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationViewModel.cpp" />
+    <ClCompile Include="DateCalculatorViewModel.cpp" />
+    <ClCompile Include="HistoryItemViewModel.cpp" />
+    <ClCompile Include="HistoryViewModel.cpp" />
+    <ClCompile Include="MemoryItemViewModel.cpp" />
+    <ClCompile Include="StandardCalculatorViewModel.cpp" />
+    <ClCompile Include="UnitConverterViewModel.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
-    <ClInclude Include="targetver.h" />
-    <ClInclude Include="ApplicationViewModel.h" />
-    <ClInclude Include="DateCalculatorViewModel.h" />
-    <ClInclude Include="HistoryItemViewModel.h" />
-    <ClInclude Include="HistoryViewModel.h" />
-    <ClInclude Include="MemoryItemViewModel.h" />
-    <ClInclude Include="StandardCalculatorViewModel.h" />
-    <ClInclude Include="UnitConverterViewModel.h" />
     <ClInclude Include="Common\AppResourceProvider.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Common\BitLength.h">
       <Filter>Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\CalculatorButtonPressedEventArgs.h">
@@ -113,6 +115,9 @@
       <Filter>Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\DateCalculator.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Common\DelegateCommand.h">
       <Filter>Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\DisplayExpressionToken.h">
@@ -145,11 +150,20 @@
     <ClInclude Include="Common\NetworkManager.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="Common\NumberBase.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Common\RadixType.h">
+      <Filter>Common</Filter>
+    </ClInclude>
     <ClInclude Include="Common\TraceLogger.h">
       <Filter>Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\Utils.h">
       <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Common\Automation\NarratorAnnouncement.h">
+      <Filter>Common\Automation</Filter>
     </ClInclude>
     <ClInclude Include="Common\Automation\NarratorNotifier.h">
       <Filter>Common\Automation</Filter>
@@ -158,6 +172,9 @@
       <Filter>DataLoaders</Filter>
     </ClInclude>
     <ClInclude Include="DataLoaders\CurrencyHttpClient.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="DataLoaders\DataLoaderMockConstants.h">
       <Filter>DataLoaders</Filter>
     </ClInclude>
     <ClInclude Include="DataLoaders\ICurrencyHttpClient.h">
@@ -169,43 +186,31 @@
     <ClInclude Include="DataLoaders\UnitConverterDataLoader.h">
       <Filter>DataLoaders</Filter>
     </ClInclude>
-    <ClInclude Include="DataLoaders\DataLoaderMockConstants.h">
-      <Filter>DataLoaders</Filter>
-    </ClInclude>
-    <ClInclude Include="Common\Automation\NarratorAnnouncement.h">
-      <Filter>Common\Automation</Filter>
-    </ClInclude>
-    <ClInclude Include="Common\BitLength.h">
-      <Filter>Common</Filter>
-    </ClInclude>
-    <ClInclude Include="Common\NumberBase.h">
-      <Filter>Common</Filter>
-    </ClInclude>
     <ClInclude Include="GraphingCalculator\EquationViewModel.h">
       <Filter>GraphingCalculator</Filter>
     </ClInclude>
     <ClInclude Include="GraphingCalculator\GraphingCalculatorViewModel.h">
       <Filter>GraphingCalculator</Filter>
     </ClInclude>
-    <ClInclude Include="GraphingCalculatorEnums.h">
-      <Filter>Common</Filter>
+    <ClInclude Include="GraphingCalculator\GraphingSettingsViewModel.h">
+      <Filter>GraphingCalculator</Filter>
     </ClInclude>
     <ClInclude Include="GraphingCalculator\VariableViewModel.h">
       <Filter>GraphingCalculator</Filter>
     </ClInclude>
-    <ClInclude Include="GraphingCalculator\GraphingSettingsViewModel.h">
-      <Filter>GraphingCalculator</Filter>
-    </ClInclude>
-    <ClInclude Include="Common\DelegateCommand.h">
-      <Filter>Common</Filter>
-    </ClInclude>
+    <ClInclude Include="ApplicationViewModel.h" />
+    <ClInclude Include="DateCalculatorViewModel.h" />
+    <ClInclude Include="GraphingCalculatorEnums.h" />
+    <ClInclude Include="HistoryItemViewModel.h" />
+    <ClInclude Include="HistoryViewModel.h" />
+    <ClInclude Include="MemoryItemViewModel.h" />
+    <ClInclude Include="StandardCalculatorViewModel.h" />
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="UnitConverterViewModel.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="DataLoaders\DefaultFromToCurrency.json">
       <Filter>DataLoaders</Filter>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Page Include="$(MSBuildThisFileDirectory)DensityStyles\Compact.xaml" />
   </ItemGroup>
 </Project>

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -178,7 +178,7 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewChangedAnnouncement(S
 NarratorAnnouncement ^ CalculatorAnnouncement::GetFunctionRemovedAnnouncement(String ^ announcement)
 {
     return ref new NarratorAnnouncement(
-        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::MostRecent);
+        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::ImportantMostRecent);
 }
 
 NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(Platform::String ^ announcement)

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -178,7 +178,7 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewChangedAnnouncement(S
 NarratorAnnouncement ^ CalculatorAnnouncement::GetFunctionRemovedAnnouncement(String ^ announcement)
 {
     return ref new NarratorAnnouncement(
-        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::ImportantMostRecent);
+        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::MostRecent);
 }
 
 NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(Platform::String ^ announcement)

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
@@ -28,10 +28,6 @@ public
         static bool IsValid(NarratorAnnouncement ^ announcement);
 
     private:
-        // Make CalculatorAnnouncement a friend class so it is the only
-        // class that can access the private constructor.
-        // friend class CalculatorAnnouncement;
-
         Platform::String ^ m_announcement;
         Platform::String ^ m_activityId;
         Windows::UI::Xaml::Automation::Peers::AutomationNotificationKind m_kind;

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
@@ -30,23 +30,25 @@ public
     private:
         // Make CalculatorAnnouncement a friend class so it is the only
         // class that can access the private constructor.
-        friend class CalculatorAnnouncement;
-
-        NarratorAnnouncement(
-            Platform::String ^ announcement,
-            Platform::String ^ activityId,
-            Windows::UI::Xaml::Automation::Peers::AutomationNotificationKind kind,
-            Windows::UI::Xaml::Automation::Peers::AutomationNotificationProcessing processing);
+        // friend class CalculatorAnnouncement;
 
         Platform::String ^ m_announcement;
         Platform::String ^ m_activityId;
         Windows::UI::Xaml::Automation::Peers::AutomationNotificationKind m_kind;
         Windows::UI::Xaml::Automation::Peers::AutomationNotificationProcessing m_processing;
+
+    internal:
+        NarratorAnnouncement(
+            Platform::String ^ announcement,
+            Platform::String ^ activityId,
+            Windows::UI::Xaml::Automation::Peers::AutomationNotificationKind kind,
+            Windows::UI::Xaml::Automation::Peers::AutomationNotificationProcessing processing);
     };
 
     // CalculatorAnnouncement is intended to contain only static methods
     // that return announcements made for the Calculator app.
-    class CalculatorAnnouncement
+public
+    ref class CalculatorAnnouncement sealed
     {
     public:
         static NarratorAnnouncement ^ GetDisplayUpdatedAnnouncement(Platform::String ^ announcement);

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -116,7 +116,7 @@ String
     }
 
     // Get english translated expression
-    String ^ englishString = LocalizationSettings::GetInstance().GetEnglishValueFromLocalizedDigits(pastedText);
+    String ^ englishString = LocalizationSettings::GetInstance()->GetEnglishValueFromLocalizedDigits(pastedText);
 
     // Removing the spaces, comma separator from the pasteExpression to allow pasting of expressions like 1  +     2+1,333
     auto pasteExpression = wstring(RemoveUnwantedCharsFromString(englishString)->Data());
@@ -614,7 +614,7 @@ ULONG32 CopyPasteManager::ProgrammerOperandLength(Platform::String ^ operand, Nu
 Platform::String ^ CopyPasteManager::RemoveUnwantedCharsFromString(Platform::String ^ input)
 {
     constexpr wchar_t unWantedChars[] = { L' ', L',', L'"', 165, 164, 8373, 36, 8353, 8361, 8362, 8358, 8377, 163, 8364, 8234, 8235, 8236, 8237, 160 };
-    input = CalculatorApp::Common::LocalizationSettings::GetInstance().RemoveGroupSeparators(input);
+    input = CalculatorApp::Common::LocalizationSettings::GetInstance()->RemoveGroupSeparators(input);
     return ref new String(Utils::RemoveUnwantedCharsFromString(input->Data(), unWantedChars).c_str());
 }
 

--- a/src/CalcViewModel/Common/DisplayExpressionToken.h
+++ b/src/CalcViewModel/Common/DisplayExpressionToken.h
@@ -50,7 +50,10 @@ public
                 m_InEditMode = val;
             }
         }
-        internal : OBSERVABLE_PROPERTY_RW(TokenType, Type);
+
+        // CSHARP_MIGRATION: TODO: this property has been changed from Internal to Public
+        // double check if this change is reasonable
+        OBSERVABLE_PROPERTY_RW(TokenType, Type);
 
     private:
         bool m_InEditMode;

--- a/src/CalcViewModel/Common/EngineResourceProvider.cpp
+++ b/src/CalcViewModel/Common/EngineResourceProvider.cpp
@@ -19,16 +19,16 @@ namespace CalculatorApp
 
     wstring EngineResourceProvider::GetCEngineString(wstring_view id)
     {
-        const auto& localizationSettings = LocalizationSettings::GetInstance();
+        LocalizationSettings^ localizationSettings = LocalizationSettings::GetInstance();
 
         if (id.compare(L"sDecimal") == 0)
         {
-            return localizationSettings.GetDecimalSeparatorStr();
+            return localizationSettings->GetDecimalSeparatorStr();
         }
 
         if (id.compare(L"sThousand") == 0)
         {
-            return localizationSettings.GetNumberGroupingSeparatorStr();
+            return localizationSettings->GetNumberGroupingSeparatorStr();
         }
 
         if (id.compare(L"sGrouping") == 0)
@@ -39,7 +39,7 @@ namespace CalculatorApp
             //   3;2;0           0x023          - group 1st 3 and then every 2 digits
             //   4;0             0x004          - group every 4 digits
             //   5;3;2;0         0x235          - group 5, then 3, then every 2
-            wstring numberGroupingString = localizationSettings.GetNumberGroupingStr();
+            wstring numberGroupingString = localizationSettings->GetNumberGroupingStr();
             return numberGroupingString;
         }
 

--- a/src/CalcViewModel/Common/LocalizationService.cpp
+++ b/src/CalcViewModel/Common/LocalizationService.cpp
@@ -371,7 +371,7 @@ void LocalizationService::UpdateFontFamilyAndSize(DependencyObject ^ target)
 
 // If successful, returns a formatter that respects the user's regional format settings,
 // as configured by running intl.cpl.
-DecimalFormatter ^ LocalizationService::GetRegionalSettingsAwareDecimalFormatter() const
+DecimalFormatter ^ LocalizationService::GetRegionalSettingsAwareDecimalFormatter()
 {
     IIterable<String ^> ^ languageIdentifiers = LocalizationService::GetLanguageIdentifiers();
     if (languageIdentifiers != nullptr)
@@ -386,7 +386,7 @@ DecimalFormatter ^ LocalizationService::GetRegionalSettingsAwareDecimalFormatter
 // as configured by running intl.cpl.
 //
 // This helper function creates a DateTimeFormatter with a TwentyFour hour clock
-DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatter(_In_ String ^ format) const
+DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatter(_In_ String ^ format)
 {
     IIterable<String ^> ^ languageIdentifiers = LocalizationService::GetLanguageIdentifiers();
     if (languageIdentifiers == nullptr)
@@ -399,7 +399,7 @@ DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatt
 
 // If successful, returns a formatter that respects the user's regional format settings,
 // as configured by running intl.cpl.
-DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatter(_In_ String ^ format, _In_ String ^ calendarIdentifier, _In_ String ^ clockIdentifier) const
+DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatter(_In_ String ^ format, _In_ String ^ calendarIdentifier, _In_ String ^ clockIdentifier)
 {
     IIterable<String ^> ^ languageIdentifiers = LocalizationService::GetLanguageIdentifiers();
     if (languageIdentifiers == nullptr)
@@ -410,7 +410,7 @@ DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatt
     return ref new DateTimeFormatter(format, languageIdentifiers, GlobalizationPreferences::HomeGeographicRegion, calendarIdentifier, clockIdentifier);
 }
 
-CurrencyFormatter ^ LocalizationService::GetRegionalSettingsAwareCurrencyFormatter() const
+CurrencyFormatter ^ LocalizationService::GetRegionalSettingsAwareCurrencyFormatter()
 {
     String ^ userCurrency =
         (GlobalizationPreferences::Currencies->Size > 0) ? GlobalizationPreferences::Currencies->GetAt(0) : StringReference(DefaultCurrencyCode.data());
@@ -423,7 +423,7 @@ CurrencyFormatter ^ LocalizationService::GetRegionalSettingsAwareCurrencyFormatt
 
     auto currencyFormatter = ref new CurrencyFormatter(userCurrency, languageIdentifiers, GlobalizationPreferences::HomeGeographicRegion);
 
-    int fractionDigits = LocalizationSettings::GetInstance().GetCurrencyTrailingDigits();
+    int fractionDigits = LocalizationSettings::GetInstance()->GetCurrencyTrailingDigits();
     currencyFormatter->FractionDigits = fractionDigits;
 
     return currencyFormatter;

--- a/src/CalcViewModel/Common/LocalizationService.h
+++ b/src/CalcViewModel/Common/LocalizationService.h
@@ -30,10 +30,7 @@ namespace CalculatorApp
             DEPENDENCY_PROPERTY_ATTACHED_WITH_DEFAULT_AND_CALLBACK(LanguageFontType, FontType, LanguageFontType::UIText);
             DEPENDENCY_PROPERTY_ATTACHED_WITH_CALLBACK(double, FontSize);
 
-        internal:
             static LocalizationService ^ GetInstance();
-            static void OverrideWithLanguage(_In_ const wchar_t* const language);
-
             Windows::UI::Xaml::FlowDirection GetFlowDirection();
             bool IsRtlLayout();
             bool GetOverrideFontApiValues();
@@ -42,7 +39,17 @@ namespace CalculatorApp
             Platform::String ^ GetFontFamilyOverride();
             Windows::UI::Text::FontWeight GetFontWeightOverride();
             double GetFontScaleFactorOverride(LanguageFontType fontType);
+            Windows::Globalization::NumberFormatting::DecimalFormatter ^ GetRegionalSettingsAwareDecimalFormatter();
+            Windows::Globalization::DateTimeFormatting::DateTimeFormatter ^ GetRegionalSettingsAwareDateTimeFormatter(_In_ Platform::String ^ format);
+            Windows::Globalization::DateTimeFormatting::DateTimeFormatter
+                ^ GetRegionalSettingsAwareDateTimeFormatter(
+                    _In_ Platform::String ^ format,
+                    _In_ Platform::String ^ calendarIdentifier,
+                    _In_ Platform::String ^ clockIdentifier);
+            Windows::Globalization::NumberFormatting::CurrencyFormatter ^ GetRegionalSettingsAwareCurrencyFormatter();
 
+        internal:
+            static void OverrideWithLanguage(_In_ const wchar_t* const language);
             void Sort(std::vector<Platform::String ^>& source);
 
             template <typename T>
@@ -55,16 +62,6 @@ namespace CalculatorApp
                     return coll.compare(str1->Begin(), str1->End(), str2->Begin(), str2->End()) < 0;
                 });
             }
-
-            Windows::Globalization::NumberFormatting::DecimalFormatter ^ GetRegionalSettingsAwareDecimalFormatter() const;
-            Windows::Globalization::DateTimeFormatting::DateTimeFormatter ^ GetRegionalSettingsAwareDateTimeFormatter(_In_ Platform::String ^ format) const;
-            Windows::Globalization::DateTimeFormatting::DateTimeFormatter
-                ^ GetRegionalSettingsAwareDateTimeFormatter(
-                    _In_ Platform::String ^ format,
-                    _In_ Platform::String ^ calendarIdentifier,
-                    _In_ Platform::String ^ clockIdentifier) const;
-
-            Windows::Globalization::NumberFormatting::CurrencyFormatter ^ GetRegionalSettingsAwareCurrencyFormatter() const;
 
             static Platform::String ^ GetNarratorReadableToken(Platform::String ^ rawToken);
             static Platform::String ^ GetNarratorReadableString(Platform::String ^ rawString);

--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -541,8 +541,3 @@ NavCategoryGroup ^ NavCategoryGroup::CreateConverterCategory()
         NavCategoryGroupInitializer{ CategoryGroupType::Converter, L"ConverterModeTextCaps", L"ConverterModeText", L"ConverterModePluralText" });
 }
 
-void NavCategory::Dummy()
-{
-
-
-}

--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -93,48 +93,6 @@ bool IsGraphingModeEnabled()
     return _isGraphingModeEnabledCached->Value;
 }
 
-//unsigned __stdcall GetUser(void* param)
-//{
-//    ::_endthreadex(0);
-//    return 0;
-//}
-//
-//bool IsGraphingModeEnabled()
-//{
-//    if (!IsGraphingModeAvailable())
-//    {
-//        return false;
-//    }
-//
-//    if (_isGraphingModeEnabledCached != nullptr)
-//    {
-//        return _isGraphingModeEnabledCached->Value;
-//    }
-//
-//    User ^ firstUser;
-//
-//    //create_task(User::FindAllAsync(UserType::LocalUser)).then([&firstUser](IVectorView<User ^> ^ users) {
-//    //    firstUser = users->GetAt(0);
-//    //}).wait();
-//
-//    //std::thread thrd([&firstUser]() {
-//    //    create_task(User::FindAllAsync(UserType::LocalUser)).then([&firstUser](IVectorView<User ^> ^ users) {
-//    //        firstUser = users->GetAt(0);
-//    //    }).wait();
-//    //});
-//    //thrd.join();
-//
-//    HANDLE handle = (HANDLE)::_beginthreadex(NULL, 0, &GetUser, NULL, 0, nullptr);
-//    ::WaitForSingleObject(handle, INFINITE);
-//
-//
-//    auto namedPolicyData = NamedPolicy::GetPolicyFromPathForUser(firstUser, L"Education", L"AllowGraphingCalculator");
-//    _isGraphingModeEnabledCached = namedPolicyData->GetBoolean() == true;
-//
-//    return _isGraphingModeEnabledCached->Value;
-//}
-//
-
 // The order of items in this list determines the order of items in the menu.
 static const list<NavCategoryInitializer> s_categoryManifest = [] {
     auto res = list<NavCategoryInitializer>{ NavCategoryInitializer{ ViewMode::Standard,

--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -133,6 +133,8 @@ namespace CalculatorApp
             static ViewMode Deserialize(Platform::Object ^ obj);
             static ViewMode GetViewModeForFriendlyName(Platform::String ^ name);
 
+            static void Dummy();
+
             static bool IsValidViewMode(ViewMode mode);
             static bool IsViewModeEnabled(ViewMode mode);
             static bool IsCalculatorViewMode(ViewMode mode);

--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -133,8 +133,6 @@ namespace CalculatorApp
             static ViewMode Deserialize(Platform::Object ^ obj);
             static ViewMode GetViewModeForFriendlyName(Platform::String ^ name);
 
-            static void Dummy();
-
             static bool IsValidViewMode(ViewMode mode);
             static bool IsViewModeEnabled(ViewMode mode);
             static bool IsCalculatorViewMode(ViewMode mode);

--- a/src/CalcViewModel/Common/RadixType.cpp
+++ b/src/CalcViewModel/Common/RadixType.cpp
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "RadixType.h"
+
+// export enum RadixType
+

--- a/src/CalcViewModel/Common/RadixType.h
+++ b/src/CalcViewModel/Common/RadixType.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace CalculatorApp
+{
+    namespace Common
+    {
+        // This is expected to be in same order as IDM_HEX, IDM_DEC, IDM_OCT, IDM_BIN
+        public enum class RadixType
+        {
+            Hex,
+            Decimal,
+            Octal,
+            Binary
+        };
+    }
+}

--- a/src/CalcViewModel/Common/TraceLogger.cpp
+++ b/src/CalcViewModel/Common/TraceLogger.cpp
@@ -147,11 +147,11 @@ namespace CalculatorApp
         TraceLoggingCommon::GetInstance()->LogLevel2Event(StringReference(EVENT_NAME_EXCEPTION), fields);
     }
 
-    void TraceLogger::LogPlatformException(ViewMode mode, wstring_view functionName, Platform::Exception ^ e)
+    void TraceLogger::LogPlatformException(ViewMode mode, Platform::String ^ functionName, Platform::Exception ^ e)
     {
         auto fields = ref new LoggingFields();
         fields->AddString(StringReference(CALC_MODE), NavCategory::GetFriendlyName(mode));
-        fields->AddString(StringReference(L"FunctionName"), StringReference(functionName.data()));
+        fields->AddString(StringReference(L"FunctionName"), functionName);
         fields->AddString(StringReference(L"Message"), e->Message);
         fields->AddInt32(StringReference(L"HRESULT"), e->HResult);
         TraceLoggingCommon::GetInstance()->LogLevel2Event(StringReference(EVENT_NAME_EXCEPTION), fields);

--- a/src/CalcViewModel/Common/TraceLogger.h
+++ b/src/CalcViewModel/Common/TraceLogger.h
@@ -83,9 +83,11 @@ namespace CalculatorApp
         void LogVariableSettingsChanged(Platform::String ^ setting);
         void LogGraphSettingsChanged(GraphSettingsType settingsType, Platform::String ^ settingValue);
         void LogGraphTheme(Platform::String ^ graphTheme);
+        // CSHARP_MIGRATION: TODO:
+        void LogPlatformException(CalculatorApp::Common::ViewMode mode, Platform::String ^ functionName, Platform::Exception ^ e);
+
         internal:
         void LogStandardException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ const std::exception& e);
-        void LogPlatformException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ Platform::Exception ^ e);
         void LogInputPasted(CalculatorApp::Common::ViewMode mode);
 
     private:

--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -10,6 +10,7 @@
 #include "Common/AppResourceProvider.h"
 #include "Common/ExpressionCommandSerializer.h"
 #include "Common/ExpressionCommandDeserializer.h"
+#include "CalcManager/NumberFormattingUtils.h"
 
 using namespace CalculatorApp;
 using namespace CalculatorApp::Common;
@@ -168,18 +169,20 @@ void Utils::TrimBack(wstring& value)
     }).base(), value.end());
 }
 
-String^ Utils::EscapeHtmlSpecialCharacters(String^ originalString, shared_ptr<vector<wchar_t>> specialCharacters)
+bool operator==(const Color& color1, const Color& color2)
+{
+    return equal_to<Color>()(color1, color2);
+}
+
+bool operator!=(const Color& color1, const Color& color2)
+{
+    return !(color1 == color2);
+}
+
+String^ CalculatorApp::Utilities::EscapeHtmlSpecialCharacters(String^ originalString)
 {
     // Construct a default special characters if not provided.
-    if (specialCharacters == nullptr)
-    {
-        specialCharacters = make_shared<vector<wchar_t>>();
-        specialCharacters->push_back(L'&');
-        specialCharacters->push_back(L'\"');
-        specialCharacters->push_back(L'\'');
-        specialCharacters->push_back(L'<');
-        specialCharacters->push_back(L'>');
-    }
+    const std::vector<wchar_t> specialCharacters {L'&', L'\"', L'\'', L'<', L'>'};
 
     bool replaceCharacters = false;
     const wchar_t* pCh;
@@ -189,7 +192,7 @@ String^ Utils::EscapeHtmlSpecialCharacters(String^ originalString, shared_ptr<ve
     // If there isn't any special character, we simply return the original string
     for (pCh = originalString->Data(); *pCh; pCh++)
     {
-        if (std::find(specialCharacters->begin(), specialCharacters->end(), *pCh) != specialCharacters->end())
+        if (std::find(specialCharacters.begin(), specialCharacters.end(), *pCh) != specialCharacters.end())
         {
             replaceCharacters = true;
             break;
@@ -233,20 +236,22 @@ String^ Utils::EscapeHtmlSpecialCharacters(String^ originalString, shared_ptr<ve
     return replaceCharacters ? replacementString : originalString;
 }
 
-bool operator==(const Color& color1, const Color& color2)
+Platform::String^ CalculatorApp::Utilities::TrimTrailingZeros(Platform::String^ input)
 {
-    return equal_to<Color>()(color1, color2);
+    std::wstring tmp(input->Data());
+    CalcManager::NumberFormattingUtils::TrimTrailingZeros(tmp);
+    return ref new Platform::String(tmp.c_str());
 }
 
-bool operator!=(const Color& color1, const Color& color2)
+bool CalculatorApp::Utilities::AreColorsEqual(Windows::UI::Color color1, Windows::UI::Color color2)
 {
-    return !(color1 == color2);
+    return Utils::AreColorsEqual(color1, color2);
 }
 
 // This method calculates the luminance ratio between White and the given background color.
 // The luminance is calculate using the RGB values and does not use the A value.
 // White or Black is returned
-SolidColorBrush ^ Utils::GetContrastColor(Color backgroundColor)
+SolidColorBrush ^ CalculatorApp::Utilities::GetContrastColor(Color backgroundColor)
 {
     auto luminance = 0.2126 * backgroundColor.R + 0.7152 * backgroundColor.G + 0.0722 * backgroundColor.B;
 
@@ -257,3 +262,9 @@ SolidColorBrush ^ Utils::GetContrastColor(Color backgroundColor)
 
     return static_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"BlackBrush"));
 }
+
+int CalculatorApp::Utilities::GetWindowId()
+{
+    return Utils::GetWindowId();
+}
+

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -399,10 +399,6 @@ namespace Utils
     void Trim(std::wstring& value);
     void TrimFront(std::wstring& value);
     void TrimBack(std::wstring& value);
-
-    Platform::String ^ EscapeHtmlSpecialCharacters(Platform::String ^ originalString, std::shared_ptr<std::vector<wchar_t>> specialCharacters = nullptr);
-
-    Windows::UI::Xaml::Media::SolidColorBrush ^ GetContrastColor(Windows::UI::Color backgroundColor);
 }
 
 // This goes into the header to define the property, in the public: section of the class
@@ -698,6 +694,18 @@ namespace CalculatorApp
 
         return to;
     }
+
+    // CSHARP_MIGRATION: TODO: Review below utils
+public
+    ref class Utilities sealed
+    {
+    public:
+        static Platform::String ^ EscapeHtmlSpecialCharacters(Platform::String ^ originalString);
+        static Platform::String^ TrimTrailingZeros(Platform::String^ input);
+        static bool AreColorsEqual(Windows::UI::Color color1, Windows::UI::Color color2);
+        static Windows::UI::Xaml::Media::SolidColorBrush ^ GetContrastColor(Windows::UI::Color backgroundColor);
+        static int GetWindowId();
+    };
 }
 
 // There's no standard definition of equality for Windows::UI::Color structs.

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -300,7 +300,7 @@ pair<wstring, wstring> CurrencyDataLoader::GetCurrencyRatioEquality(_In_ const U
                 double ratio = (iter2->second).ratio;
                 double rounded = RoundCurrencyRatio(ratio);
 
-                auto digit = LocalizationSettings::GetInstance().GetDigitSymbolFromEnUsDigit(L'1');
+                auto digit = LocalizationSettings::GetInstance()->GetDigitSymbolFromEnUsDigit(L'1');
                 auto digitSymbol = ref new String(&digit, 1);
                 auto roundedFormat = m_ratioFormatter->Format(rounded);
 

--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -45,13 +45,13 @@ DateCalculatorViewModel::DateCalculatorViewModel()
     , m_StrDateResult(L"")
     , m_StrDateResultAutomationName(L"")
 {
-    const auto & localizationSettings = LocalizationSettings::GetInstance();
+    LocalizationSettings^ localizationSettings = LocalizationSettings::GetInstance();
 
     // Initialize Date Output format instances
-    InitializeDateOutputFormats(localizationSettings.GetCalendarIdentifier());
+    InitializeDateOutputFormats(localizationSettings->GetCalendarIdentifier());
 
     // Initialize Date Calc engine
-    m_dateCalcEngine = ref new DateCalculationEngine(localizationSettings.GetCalendarIdentifier());
+    m_dateCalcEngine = ref new DateCalculationEngine(localizationSettings->GetCalendarIdentifier());
     // Initialize dates of DatePicker controls to today's date
     auto calendar = ref new Calendar();
     // We force the timezone to UTC, in order to avoid being affected by Daylight Saving Time
@@ -68,7 +68,7 @@ DateCalculatorViewModel::DateCalculatorViewModel()
 
     // Initialize the list separator delimiter appended with a space at the end, e.g. ", "
     // This will be used for date difference formatting: Y years, M months, W weeks, D days
-    m_listSeparator = localizationSettings.GetListSeparator() + L" ";
+    m_listSeparator = localizationSettings->GetListSeparator() + L" ";
 
     // Initialize the output results
     UpdateDisplayResult();
@@ -77,7 +77,7 @@ DateCalculatorViewModel::DateCalculatorViewModel()
     for (int i = 0; i <= c_maxOffsetValue; i++)
     {
         wstring numberStr(to_wstring(i));
-        localizationSettings.LocalizeDisplayValue(&numberStr);
+        localizationSettings->LocalizeDisplayValue(&numberStr);
         m_offsetValues->Append(ref new String(numberStr.c_str()));
     }
 
@@ -378,7 +378,7 @@ void DateCalculatorViewModel::OnCopyCommand(Platform::Object ^ parameter)
 String ^ DateCalculatorViewModel::GetLocalizedNumberString(int value) const
 {
     wstring numberStr(to_wstring(value));
-    LocalizationSettings::GetInstance().LocalizeDisplayValue(&numberStr);
+    LocalizationSettings::GetInstance()->LocalizeDisplayValue(&numberStr);
     return ref new String(numberStr.c_str());
 }
 

--- a/src/CalcViewModel/GraphingCalculator/EquationViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/EquationViewModel.cpp
@@ -245,7 +245,7 @@ namespace CalculatorApp::ViewModel
             return;
         }
 
-        Platform::String ^ separator = ref new String(LocalizationSettings::GetInstance().GetListSeparator().c_str());
+        Platform::String ^ separator = ref new String(LocalizationSettings::GetInstance()->GetListSeparator().c_str());
 
         wstring error;
         if ((graphEquation->TooComplexFeatures & KeyGraphFeaturesFlag::Domain) == KeyGraphFeaturesFlag::Domain)

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -57,15 +57,15 @@ void HistoryViewModel::ReloadHistory(_In_ ViewMode currentMode)
 
     auto historyListModel = m_calculatorManager->GetHistoryItems(m_currentMode);
     auto historyListVM = ref new Platform::Collections::Vector<HistoryItemViewModel ^>();
-    const auto& localizer = LocalizationSettings::GetInstance();
+    LocalizationSettings^ localizer = LocalizationSettings::GetInstance();
     if (historyListModel.size() > 0)
     {
         for (auto ritr = historyListModel.rbegin(); ritr != historyListModel.rend(); ++ritr)
         {
             wstring expression = (*ritr)->historyItemVector.expression;
             wstring result = (*ritr)->historyItemVector.result;
-            localizer.LocalizeDisplayValue(&expression);
-            localizer.LocalizeDisplayValue(&result);
+            localizer->LocalizeDisplayValue(&expression);
+            localizer->LocalizeDisplayValue(&result);
 
             auto item = ref new HistoryItemViewModel(
                 ref new Platform::String(expression.c_str()),
@@ -83,11 +83,11 @@ void HistoryViewModel::ReloadHistory(_In_ ViewMode currentMode)
 void HistoryViewModel::OnHistoryItemAdded(_In_ unsigned int addedItemIndex)
 {
     auto newItem = m_calculatorManager->GetHistoryItem(addedItemIndex);
-    const auto& localizer = LocalizationSettings::GetInstance();
+    LocalizationSettings^ localizer = LocalizationSettings::GetInstance();
     wstring expression = newItem->historyItemVector.expression;
     wstring result = newItem->historyItemVector.result;
-    localizer.LocalizeDisplayValue(&expression);
-    localizer.LocalizeDisplayValue(&result);
+    localizer->LocalizeDisplayValue(&expression);
+    localizer->LocalizeDisplayValue(&result);
     auto item = ref new HistoryItemViewModel(
         ref new Platform::String(expression.c_str()),
         ref new Platform::String(result.c_str()),
@@ -133,7 +133,7 @@ void HistoryViewModel::DeleteItem(_In_ HistoryItemViewModel ^ e)
     }
     // Adding 1 to the history item index to provide 1-based numbering on announcements.
     wstring localizedIndex = to_wstring(itemIndex + 1);
-    LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedIndex);
+    LocalizationSettings::GetInstance()->LocalizeDisplayValue(&localizedIndex);
     m_localizedHistorySlotCleared = AppResourceProvider::GetInstance()->GetResourceString(HistoryResourceKeys::HistorySlotCleared);
     String ^ announcement = LocalizationStringUtil::GetLocalizedString(m_localizedHistorySlotCleared, StringReference(localizedIndex.c_str()));
     HistoryAnnouncement = CalculatorAnnouncement::GetHistorySlotClearedAnnouncement(announcement);

--- a/src/CalcViewModel/HistoryViewModel.h
+++ b/src/CalcViewModel/HistoryViewModel.h
@@ -48,13 +48,13 @@ namespace CalculatorApp
             event HideHistoryClickedHandler ^ HideHistoryClicked;
             event HistoryItemClickedHandler ^ HistoryItemClicked;
             void ShowItem(_In_ CalculatorApp::ViewModel::HistoryItemViewModel ^ e);
+            void DeleteItem(_In_ CalculatorApp::ViewModel::HistoryItemViewModel ^ e);
 
             internal : HistoryViewModel(_In_ CalculationManager::CalculatorManager* calculatorManager);
             void SetCalculatorDisplay(CalculatorDisplay& calculatorDisplay);
             void ReloadHistory(_In_ CalculatorApp::Common::ViewMode currentMode);
             unsigned long long GetMaxItemSize();
 
-            void DeleteItem(_In_ CalculatorApp::ViewModel::HistoryItemViewModel ^ e);
 
         private:
             CalculationManager::CalculatorManager* const m_calculatorManager;

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -25,7 +25,6 @@ using namespace Windows::UI::Core;
 using namespace Windows::UI::Popups;
 using namespace Windows::Storage::Streams;
 using namespace Windows::Foundation::Collections;
-using namespace Utils;
 using namespace concurrency;
 
 constexpr int StandardModePrecision = 16;
@@ -118,7 +117,7 @@ StandardCalculatorViewModel::StandardCalculatorViewModel()
     m_HistoryVM = ref new HistoryViewModel(&m_standardCalculatorManager);
     m_HistoryVM->SetCalculatorDisplay(m_calculatorDisplay);
 
-    m_decimalSeparator = LocalizationSettings::GetInstance().GetDecimalSeparator();
+    m_decimalSeparator = LocalizationSettings::GetInstance()->GetDecimalSeparator();
 
     if (CoreWindow::GetForCurrentThread() != nullptr)
     {
@@ -138,7 +137,7 @@ StandardCalculatorViewModel::StandardCalculatorViewModel()
 String ^ StandardCalculatorViewModel::LocalizeDisplayValue(_In_ wstring const& displayValue)
 {
     wstring result(displayValue);
-    LocalizationSettings::GetInstance().LocalizeDisplayValue(&result);
+    LocalizationSettings::GetInstance()->LocalizeDisplayValue(&result);
     return ref new Platform::String(result.c_str());
 }
 
@@ -170,13 +169,13 @@ String ^ StandardCalculatorViewModel::CalculateNarratorDisplayValue(_In_ wstring
 String ^ StandardCalculatorViewModel::GetNarratorStringReadRawNumbers(_In_ String ^ localizedDisplayValue)
 {
     wstring ws;
-    const auto& locSettings = LocalizationSettings::GetInstance();
+    LocalizationSettings^ locSettings = LocalizationSettings::GetInstance();
 
     // Insert a space after each digit in the string, to force Narrator to read them as separate numbers.
     for (const wchar_t& c : localizedDisplayValue)
     {
         ws += c;
-        if (locSettings.IsLocalizedHexDigit(c))
+        if (locSettings->IsLocalizedHexDigit(c))
         {
             ws += L' ';
         }
@@ -230,7 +229,7 @@ void StandardCalculatorViewModel::SetParenthesisCount(_In_ unsigned int parenthe
 void StandardCalculatorViewModel::SetOpenParenthesisCountNarratorAnnouncement()
 {
     wstring localizedParenthesisCount = to_wstring(m_OpenParenthesisCount).c_str();
-    LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedParenthesisCount);
+    LocalizationSettings::GetInstance()->LocalizeDisplayValue(&localizedParenthesisCount);
 
     if (m_localizedOpenParenthesisCountChangedAutomationFormat == nullptr)
     {
@@ -329,7 +328,7 @@ void StandardCalculatorViewModel::SetTokens(_Inout_ shared_ptr<vector<pair<wstri
         return;
     }
 
-    const auto& localizer = LocalizationSettings::GetInstance();
+    LocalizationSettings^ localizer = LocalizationSettings::GetInstance();
 
     const wstring separator = L" ";
     for (unsigned int i = 0; i < nTokens; ++i)
@@ -338,7 +337,7 @@ void StandardCalculatorViewModel::SetTokens(_Inout_ shared_ptr<vector<pair<wstri
 
         Common::TokenType type;
         bool isEditable = currentToken.second != -1;
-        localizer.LocalizeDisplayValue(&(currentToken.first));
+        localizer->LocalizeDisplayValue(&(currentToken.first));
 
         if (!isEditable)
         {
@@ -392,7 +391,7 @@ String ^ StandardCalculatorViewModel::GetCalculatorExpressionAutomationName()
 
 void StandardCalculatorViewModel::SetMemorizedNumbers(const vector<wstring>& newMemorizedNumbers)
 {
-    const auto& localizer = LocalizationSettings::GetInstance();
+    LocalizationSettings^ localizer = LocalizationSettings::GetInstance();
     if (newMemorizedNumbers.size() == 0) // Memory has been cleared
     {
         MemorizedNumbers->Clear();
@@ -408,7 +407,7 @@ void StandardCalculatorViewModel::SetMemorizedNumbers(const vector<wstring>& new
 
             MemoryItemViewModel ^ memorySlot = ref new MemoryItemViewModel(this);
             memorySlot->Position = 0;
-            localizer.LocalizeDisplayValue(&stringValue);
+            localizer->LocalizeDisplayValue(&stringValue);
             memorySlot->Value = ref new String(stringValue.c_str());
 
             MemorizedNumbers->InsertAt(0, memorySlot);
@@ -426,7 +425,7 @@ void StandardCalculatorViewModel::SetMemorizedNumbers(const vector<wstring>& new
         for (unsigned int i = 0; i < MemorizedNumbers->Size; i++)
         {
             auto newStringValue = newMemorizedNumbers.at(i);
-            localizer.LocalizeDisplayValue(&newStringValue);
+            localizer->LocalizeDisplayValue(&newStringValue);
 
             // If the value is different, update the value
             if (MemorizedNumbers->GetAt(i)->Value != StringReference(newStringValue.c_str()))
@@ -1001,10 +1000,10 @@ ButtonInfo StandardCalculatorViewModel::MapCharacterToButtonId(char16 ch)
 
     if (result.buttonId == NumbersAndOperatorsEnum::None)
     {
-        if (LocalizationSettings::GetInstance().IsLocalizedDigit(ch))
+        if (LocalizationSettings::GetInstance()->IsLocalizedDigit(ch))
         {
             result.buttonId =
-                NumbersAndOperatorsEnum::Zero + static_cast<NumbersAndOperatorsEnum>(ch - LocalizationSettings::GetInstance().GetDigitSymbolFromEnUsDigit('0'));
+                NumbersAndOperatorsEnum::Zero + static_cast<NumbersAndOperatorsEnum>(ch - LocalizationSettings::GetInstance()->GetDigitSymbolFromEnUsDigit('0'));
             result.canSendNegate = true;
         }
     }
@@ -1044,7 +1043,7 @@ void StandardCalculatorViewModel::OnMemoryItemChanged(unsigned int indexOfMemory
         String ^ localizedValue = memSlot->Value;
 
         wstring localizedIndex = to_wstring(indexOfMemory + 1);
-        LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedIndex);
+        LocalizationSettings::GetInstance()->LocalizeDisplayValue(&localizedIndex);
 
         if (m_localizedMemoryItemChangedAutomationFormat == nullptr)
         {
@@ -1116,7 +1115,7 @@ void StandardCalculatorViewModel::OnMemoryClear(_In_ Object ^ memoryItemPosition
             TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryClear, GetCalculatorMode());
 
             wstring localizedIndex = to_wstring(boxedPosition->Value + 1);
-            LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedIndex);
+            LocalizationSettings::GetInstance()->LocalizeDisplayValue(&localizedIndex);
 
             if (m_localizedMemoryItemClearedAutomationFormat == nullptr)
             {
@@ -1216,7 +1215,7 @@ String ^ StandardCalculatorViewModel::GetRawDisplayValue()
     }
     else
     {
-        return LocalizationSettings::GetInstance().RemoveGroupSeparators(DisplayValue);
+        return LocalizationSettings::GetInstance()->RemoveGroupSeparators(DisplayValue);
     }
 }
 
@@ -1535,7 +1534,7 @@ size_t StandardCalculatorViewModel::LengthWithoutPadding(wstring str)
 
 wstring StandardCalculatorViewModel::AddPadding(wstring binaryString)
 {
-    if (LocalizationSettings::GetInstance().GetEnglishValueFromLocalizedDigits(StringReference(binaryString.c_str())) == L"0")
+    if (LocalizationSettings::GetInstance()->GetEnglishValueFromLocalizedDigits(StringReference(binaryString.c_str())) == L"0")
     {
         return binaryString;
     }
@@ -1571,13 +1570,13 @@ void StandardCalculatorViewModel::UpdateProgrammerPanelDisplay()
             binaryDisplayString = m_standardCalculatorManager.GetResultForRadix(2, precision, true);
         }
     }
-    const auto& localizer = LocalizationSettings::GetInstance();
+    LocalizationSettings^ localizer = LocalizationSettings::GetInstance();
     binaryDisplayString = AddPadding(binaryDisplayString);
 
-    localizer.LocalizeDisplayValue(&hexDisplayString);
-    localizer.LocalizeDisplayValue(&decimalDisplayString);
-    localizer.LocalizeDisplayValue(&octalDisplayString);
-    localizer.LocalizeDisplayValue(&binaryDisplayString);
+    localizer->LocalizeDisplayValue(&hexDisplayString);
+    localizer->LocalizeDisplayValue(&decimalDisplayString);
+    localizer->LocalizeDisplayValue(&octalDisplayString);
+    localizer->LocalizeDisplayValue(&binaryDisplayString);
 
     HexDisplayValue = ref new Platform::String(hexDisplayString.c_str());
     DecimalDisplayValue = ref new Platform::String(decimalDisplayString.c_str());
@@ -1609,7 +1608,7 @@ void StandardCalculatorViewModel::UpdateOperand(int pos, String ^ text)
 {
     pair<wstring, int> p = m_tokens->at(pos);
 
-    String ^ englishString = LocalizationSettings::GetInstance().GetEnglishValueFromLocalizedDigits(text);
+    String ^ englishString = LocalizationSettings::GetInstance()->GetEnglishValueFromLocalizedDigits(text);
     p.first = englishString->Data();
 
     int commandPos = p.second;

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -244,6 +244,21 @@ namespace CalculatorApp
             void ResetCalcManager(bool clearMemory);
             void SendCommandToCalcManager(int command);
 
+        public:
+            // CSHARP_MIGRATION: TODO: check if these still need to be internal
+            // Memory feature related methods. They are internal because they need to called from the MainPage code-behind
+            void OnMemoryButtonPressed();
+            void OnMemoryItemPressed(Platform::Object ^ memoryItemPosition);
+            void OnMemoryAdd(Platform::Object ^ memoryItemPosition);
+            void OnMemorySubtract(Platform::Object ^ memoryItemPosition);
+            void OnMemoryClear(_In_ Platform::Object ^ memoryItemPosition);
+            void SelectHistoryItem(HistoryItemViewModel ^ item);
+            void SwitchProgrammerModeBase(CalculatorApp::Common::NumberBase calculatorBase);
+            void SetBitshiftRadioButtonCheckedAnnouncement(Platform::String ^ announcement);
+            void SetOpenParenthesisCountNarratorAnnouncement();
+            void SwitchAngleType(NumbersAndOperatorsEnum num);
+            void FtoEButtonToggled();
+
         internal:
             void OnPaste(Platform::String ^ pastedString);
             void OnCopyCommand(Platform::Object ^ parameter);
@@ -251,23 +266,14 @@ namespace CalculatorApp
 
             ButtonInfo MapCharacterToButtonId(char16 ch);
 
-            // Memory feature related methods. They are internal because they need to called from the MainPage code-behind
-            void OnMemoryButtonPressed();
-            void OnMemoryItemPressed(Platform::Object ^ memoryItemPosition);
-            void OnMemoryAdd(Platform::Object ^ memoryItemPosition);
-            void OnMemorySubtract(Platform::Object ^ memoryItemPosition);
-            void OnMemoryClear(_In_ Platform::Object ^ memoryItemPosition);
-
             void OnInputChanged();
             void DisplayPasteError();
             void SetParenthesisCount(_In_ unsigned int parenthesisCount);
-            void SetOpenParenthesisCountNarratorAnnouncement();
             void OnNoRightParenAdded();
             void SetNoParenAddedNarratorAnnouncement();
             void OnMaxDigitsReached();
             void OnBinaryOperatorReceived();
             void OnMemoryItemChanged(unsigned int indexOfMemory);
-            void SetBitshiftRadioButtonCheckedAnnouncement(Platform::String ^ announcement);
 
             Platform::String ^ GetLocalizedStringFormat(Platform::String ^ format, Platform::String ^ displayValue);
             void OnPropertyChanged(Platform::String ^ propertyname);
@@ -276,10 +282,7 @@ namespace CalculatorApp
             Platform::String ^ GetRawDisplayValue();
             void Recalculate(bool fromHistory = false);
             bool IsOperator(CalculationManager::Command cmdenum);
-            void FtoEButtonToggled();
-            void SwitchProgrammerModeBase(CalculatorApp::Common::NumberBase calculatorBase);
-            void SetMemorizedNumbersString();
-            void SwitchAngleType(NumbersAndOperatorsEnum num);
+            void SetMemorizedNumbersString();   
             void ResetDisplay();
           
             void SetPrecision(int32_t precision);
@@ -291,7 +294,7 @@ namespace CalculatorApp
             {
                 return m_CurrentAngleType;
             }
-            void SelectHistoryItem(HistoryItemViewModel ^ item);
+            
         private:
             void SetMemorizedNumbers(const std::vector<std::wstring>& memorizedNumbers);
             void UpdateProgrammerPanelDisplay();

--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -128,7 +128,7 @@ UnitConverterViewModel::UnitConverterViewModel(const shared_ptr<UCM::IUnitConver
     m_decimalFormatter = localizationService->GetRegionalSettingsAwareDecimalFormatter();
     m_decimalFormatter->FractionDigits = 0;
     m_decimalFormatter->IsGrouped = true;
-    m_decimalSeparator = LocalizationSettings::GetInstance().GetDecimalSeparator();
+    m_decimalSeparator = LocalizationSettings::GetInstance()->GetDecimalSeparator();
 
     m_currencyFormatter = localizationService->GetRegionalSettingsAwareCurrencyFormatter();
     m_currencyFormatter->IsGrouped = true;
@@ -922,10 +922,10 @@ NumbersAndOperatorsEnum UnitConverterViewModel::MapCharacterToButtonId(const wch
 
     if (mappedValue == NumbersAndOperatorsEnum::None)
     {
-        if (LocalizationSettings::GetInstance().IsLocalizedDigit(ch))
+        if (LocalizationSettings::GetInstance()->IsLocalizedDigit(ch))
         {
             mappedValue = NumbersAndOperatorsEnum::Zero
-                          + static_cast<NumbersAndOperatorsEnum>(ch - LocalizationSettings::GetInstance().GetDigitSymbolFromEnUsDigit(L'0'));
+                          + static_cast<NumbersAndOperatorsEnum>(ch - LocalizationSettings::GetInstance()->GetDigitSymbolFromEnUsDigit(L'0'));
             canSendNegate = true;
         }
     }

--- a/src/CalcViewModel/UnitConverterViewModel.h
+++ b/src/CalcViewModel/UnitConverterViewModel.h
@@ -70,6 +70,18 @@ namespace CalculatorApp
                 return AccessibleName;
             }
 
+            // CSHARP_MIGRATION: TODO:
+        public:
+            bool IsModelUnitWhimsical()
+            {
+                return m_original.isWhimsical;
+            }
+
+            int ModelUnitID()
+            {
+                return m_original.id;
+            }
+
             internal : const UnitConversionManager::Unit& GetModelUnit() const
             {
                 return m_original;
@@ -87,11 +99,14 @@ namespace CalculatorApp
             {
             }
 
-            bool IsWhimsical() const
+        // CSHARP_MIGRATION: TODO: double check below method's accessor
+        public:
+            bool IsWhimsical()
             {
                 return m_Unit->GetModelUnit().isWhimsical;
             }
 
+        public:
             Platform::String ^ GetLocalizedAutomationName();
 
         public:


### PR DESCRIPTION
## UI C# Migration: Step1 - Make sure that CalcViewModel can be invoked by C# UI project


### Description of the changes:
- CalcViewModel.vcxproj : edited project properties
- LocalizationSettings: export as a ref class
- LocalizationService: export more methods
- Utils: export utilities as a ref class for managed code to reference
- StandardCalculatorViewModel: export more methods

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build Passed

### Misc:
Later we will port Unit-Tests for the ViewModel and then we can setup a Pipeline to ensure the quality of our PRs.