### PR TITLE
Check null reference before invoking event handlers

### DIFF
--- a/src/Calculator/Common/AlwaysSelectedCollectionView.cs
+++ b/src/Calculator/Common/AlwaysSelectedCollectionView.cs
@@ -34,7 +34,7 @@ namespace CalculatorApp
                     if (newCurrentPosition != -1)
                     {
                         m_currentPosition = newCurrentPosition;
-                        CurrentChanged(this, null);
+                        CurrentChanged?.Invoke(this, null);
                         return true;
                     }
                 }
@@ -46,7 +46,7 @@ namespace CalculatorApp
                 {
                     Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, new Windows.UI.Core.DispatchedHandler(() =>
                     {
-                        CurrentChanged(this, null);
+                        CurrentChanged?.Invoke(this, null);
                     })).AsTask().Wait();
                 }
                 return false;
@@ -60,7 +60,7 @@ namespace CalculatorApp
                 }
 
                 m_currentPosition = index;
-                CurrentChanged(this, null);
+                CurrentChanged?.Invoke(this, null);
                 return true;
             }
 
@@ -219,7 +219,7 @@ namespace CalculatorApp
             void OnSourceBindableVectorChanged(Windows.UI.Xaml.Interop.IBindableObservableVector source, object e)
             {
                 Windows.Foundation.Collections.IVectorChangedEventArgs args = (Windows.Foundation.Collections.IVectorChangedEventArgs)e;
-                VectorChanged(this, args);
+                VectorChanged?.Invoke(this, args);
             }
 
             public event EventHandler<object> CurrentChanged;

--- a/src/Calculator/Controls/EquationTextBox.cs
+++ b/src/Calculator/Controls/EquationTextBox.cs
@@ -406,7 +406,7 @@ namespace CalculatorApp
 
             private void OnEquationButtonClicked(object sender, RoutedEventArgs e)
             {
-                EquationButtonClicked(this, new RoutedEventArgs());
+                EquationButtonClicked?.Invoke(this, new RoutedEventArgs());
 
                 SetEquationButtonTooltipAndAutomationName();
             }
@@ -424,7 +424,7 @@ namespace CalculatorApp
                     m_richEditBox.MathText = "";
                 }
 
-                RemoveButtonClicked(this, new RoutedEventArgs());
+                RemoveButtonClicked?.Invoke(this, new RoutedEventArgs());
 
                 if (m_functionButton != null)
                 {
@@ -452,7 +452,7 @@ namespace CalculatorApp
 
             private void OnFunctionButtonClicked(object sender, RoutedEventArgs e)
             {
-                KeyGraphFeaturesButtonClicked(this, new RoutedEventArgs());
+                KeyGraphFeaturesButtonClicked?.Invoke(this, new RoutedEventArgs());
             }
 
             private void OnFunctionMenuButtonClicked(object sender, RoutedEventArgs e)
@@ -463,7 +463,7 @@ namespace CalculatorApp
                     m_richEditBox.SubmitEquation(EquationSubmissionSource.FOCUS_LOST);
                 }
 
-                KeyGraphFeaturesButtonClicked(this, new RoutedEventArgs());
+                KeyGraphFeaturesButtonClicked?.Invoke(this, new RoutedEventArgs());
             }
 
             private void OnRichEditMenuOpened(object sender, object args)
@@ -614,12 +614,12 @@ namespace CalculatorApp
                     }
                 }
 
-                EquationSubmitted(this, args);
+                EquationSubmitted?.Invoke(this, args);
             }
 
             private void OnEquationFormatRequested(object sender, MathRichEditBoxFormatRequest args)
             {
-                EquationFormatRequested(this, args);
+                EquationFormatRequested?.Invoke(this, args);
             }
         }
     }

--- a/src/Calculator/Controls/MathRichEditBox.cs
+++ b/src/Calculator/Controls/MathRichEditBox.cs
@@ -150,7 +150,7 @@ namespace CalculatorApp
                 {
                     // Request the final formatting of the text
                     var formatRequest = new MathRichEditBoxFormatRequest(newVal);
-                    FormatRequest(this, formatRequest);
+                    FormatRequest?.Invoke(this, formatRequest);
 
                     if (!string.IsNullOrEmpty(formatRequest.FormattedText))
                     {
@@ -158,11 +158,11 @@ namespace CalculatorApp
                     }
 
                     SetValue(MathTextProperty, newVal);
-                    EquationSubmitted(this, new MathRichEditBoxSubmission(true, source));
+                    EquationSubmitted?.Invoke(this, new MathRichEditBoxSubmission(true, source));
                 }
                 else
                 {
-                    EquationSubmitted(this, new MathRichEditBoxSubmission(false, source));
+                    EquationSubmitted?.Invoke(this, new MathRichEditBoxSubmission(false, source));
                 }
             }
 

--- a/src/Calculator/Utils/DispatcherTimerDelayer.cs
+++ b/src/Calculator/Utils/DispatcherTimerDelayer.cs
@@ -37,7 +37,7 @@ namespace CalculatorApp
         private void Timer_Tick(object sender, object e)
         {
             m_timer.Stop();
-            Action(this, null);
+            Action?.Invoke(this, null);
         }
 
         private DispatcherTimer m_timer;

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
@@ -407,7 +407,7 @@ namespace CalculatorApp
 
         private void EquationTextBox_KeyGraphFeaturesButtonClicked(object sender, RoutedEventArgs e)
         {
-            KeyGraphFeaturesRequested(this, GetViewModelFromEquationTextBox(sender));
+            KeyGraphFeaturesRequested?.Invoke(this, GetViewModelFromEquationTextBox(sender));
         }
 
         private void EquationTextBox_EquationButtonClicked(object sender, RoutedEventArgs e)
@@ -565,7 +565,7 @@ namespace CalculatorApp
 
         private void EquationTextBox_EquationFormatRequested(object sender, MathRichEditBoxFormatRequest e)
         {
-            EquationFormatRequested(sender, e);
+            EquationFormatRequested?.Invoke(sender, e);
         }
 
         private void Slider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)

--- a/src/Calculator/Views/TitleBar.xaml.cs
+++ b/src/Calculator/Views/TitleBar.xaml.cs
@@ -199,7 +199,7 @@ namespace CalculatorApp
 
         private void AlwaysOnTopButton_Click(object sender, RoutedEventArgs e)
         {
-            AlwaysOnTopClick(this, e);
+            AlwaysOnTopClick?.Invoke(this, e);
         }
 
         private Windows.ApplicationModel.Core.CoreApplicationViewTitleBar m_coreTitleBar;


### PR DESCRIPTION
## Fixes null reference crashing


### Description of the changes:
- In the C++/CX codebase, event handler is safe to invoke without checking if it's null, however, in C#, we have do so to prevent from exceptions.
- using `?.Invoke()` on event handlers


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build passed
- Unit Tests and UI Tests are not applicable so far.

