### PR TITLE
Fixes problems of the migration of OBSERVABLE_PROPERTY_RW

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
@@ -61,7 +61,7 @@ namespace CalculatorApp
                 if (m_Equations != value)
                 {
                     m_Equations = value;
-                    RaisePropertyChanged("m_Equations");
+                    RaisePropertyChanged(nameof(Equations));
                 }
             }
         }
@@ -75,7 +75,7 @@ namespace CalculatorApp
                 if (m_Variables != value)
                 {
                     m_Variables = value;
-                    RaisePropertyChanged("m_Variables");
+                    RaisePropertyChanged(nameof(Variables));
                 }
             }
         }
@@ -89,7 +89,7 @@ namespace CalculatorApp
                 if (m_AvailableColors != value)
                 {
                     m_AvailableColors = value;
-                    RaisePropertyChanged("m_AvailableColors");
+                    RaisePropertyChanged(nameof(AvailableColors));
                 }
             }
         }
@@ -104,7 +104,7 @@ namespace CalculatorApp
                 if (m_IsMatchAppTheme != value)
                 {
                     m_IsMatchAppTheme = value;
-                    RaisePropertyChanged("m_IsMatchAppTheme");
+                    RaisePropertyChanged(nameof(IsMatchAppTheme));
                 }
             }
         }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cs
@@ -142,7 +142,7 @@ namespace CalculatorApp
                 if (m_IsKeyGraphFeaturesVisible != value)
                 {
                     m_IsKeyGraphFeaturesVisible = value;
-                    RaisePropertyChanged("IsKeyGraphFeaturesVisible");
+                    RaisePropertyChanged(nameof(IsKeyGraphFeaturesVisible));
                 }
             }
         }
@@ -176,7 +176,7 @@ namespace CalculatorApp
                 if (m_IsMatchAppTheme != value)
                 {
                     m_IsMatchAppTheme = value;
-                    RaisePropertyChanged("IsMatchAppTheme");
+                    RaisePropertyChanged(nameof(IsMatchAppTheme));
                 }
             }
         }
@@ -190,7 +190,7 @@ namespace CalculatorApp
                 if (m_IsManualAdjustment != value)
                 {
                     m_IsManualAdjustment = value;
-                    RaisePropertyChanged("IsManualAdjustment");
+                    RaisePropertyChanged(nameof(IsManualAdjustment));
                 }
             }
         }

--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml.cs
@@ -39,7 +39,7 @@ namespace CalculatorApp
                 if (m_viewModel != value)
                 {
                     m_viewModel = value;
-                    RaisePropertyChanged("ViewModel");
+                    RaisePropertyChanged(nameof(ViewModel));
                 }
             }
         }


### PR DESCRIPTION
## Fixes some problems of the migration of OBSERVABLE_PROPERTY_RW


### Description of the changes:
- `"m_Foo"` should be `"Foo"`
-  use `nameof(Foo)` instead of `"Foo"` to leverage compile-time checking

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build passed
- UT is not applicable at current stage.

