### PR TITLE
fixes crash in MathRichEditBox.ctor()

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cs
+++ b/src/Calculator/Controls/MathRichEditBox.cs
@@ -93,7 +93,7 @@ namespace CalculatorApp
                                 "BeDD/jxKhz/yfVNA11t4uA==", // Microsoft.WindowsCalculator.Dev
                                 "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.");
                 }
-                else if(packageName == "Microsoft.WindowsCalculator.Dev")
+                else if(packageName == "Microsoft.WindowsCalculator")
                 {
                     LimitedAccessFeatures.TryUnlockFeature(
                                 "com.microsoft.windows.richeditmath",

--- a/src/Calculator/Controls/MathRichEditBox.cs
+++ b/src/Calculator/Controls/MathRichEditBox.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -8,7 +8,7 @@ using Windows.UI.Core;
 using Windows.UI.Text;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Input;
-//using Microsoft.WRL;
+using Windows.ApplicationModel;
 
 namespace CalculatorApp
 {
@@ -84,6 +84,23 @@ namespace CalculatorApp
         {
             public MathRichEditBox()
             {
+                string packageName = Package.Current.Id.Name;
+
+                if(packageName == "Microsoft.WindowsCalculator.Dev")
+                {
+                    LimitedAccessFeatures.TryUnlockFeature(
+                                "com.microsoft.windows.richeditmath",
+                                "BeDD/jxKhz/yfVNA11t4uA==", // Microsoft.WindowsCalculator.Dev
+                                "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.");
+                }
+                else if(packageName == "Microsoft.WindowsCalculator.Dev")
+                {
+                    LimitedAccessFeatures.TryUnlockFeature(
+                                "com.microsoft.windows.richeditmath",
+                                "pfanNuxnzo+mAkBQ3N/rGQ==", // Microsoft.WindowsCalculator
+                                "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.");
+                }
+
                 TextDocument.SetMathMode(RichEditMathMode.MathOnly);
                 LosingFocus += OnLosingFocus;
                 KeyUp += OnKeyUp;


### PR DESCRIPTION
## Fixes fixes crash in MathRichEditBox.ctor()


### Description of the changes:
- The root cause is that RichEdit's math mode is a limited feature and the Calculator has to enable the feature explicitly before using it.
- Enable the feature via `LimitedAccessFeatures.TryUnlockFeature()`

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build passed
- UT is not applicable at current stage

