### PR TITLE
Added a link copy of CalcViewModel to temporarily pass Unit Tests

### DIFF
--- a/src/CalcViewModelCopyForUT/CalcViewModelCopyForUT.vcxproj
+++ b/src/CalcViewModelCopyForUT/CalcViewModelCopyForUT.vcxproj
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{cc9b4fa7-d746-4f52-9401-0ad1b4d6b16d}</ProjectGuid>
+    <Keyword>StaticLibrary</Keyword>
+    <RootNamespace>CalcViewModelCopyForUT</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <PropertyGroup>
+    <GenerateManifest>false</GenerateManifest>
+    <GenerateProjectSpecificOutputFolder>true</GenerateProjectSpecificOutputFolder>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir);C:\Users\zhangh\han_projects\caluimig\calculator\src\CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|arm64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|arm64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <CompileAsWinRT>true</CompileAsWinRT>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <DisableSpecificWarnings>4453</DisableSpecificWarnings>
+      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
+      <GenerateWindowsMetadata>false</GenerateWindowsMetadata>
+    </Link>
+    <Lib>
+      <AdditionalOptions>/ignore:4264 %(AdditionalOptions)</AdditionalOptions>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(IsStoreBuild)' == 'True'">
+    <ClCompile>
+      <AdditionalOptions>/DSEND_DIAGNOSTICS %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\CalcViewModel\ApplicationViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\Common\AlwaysSelectedCollectionView.h" />
+    <ClInclude Include="..\CalcViewModel\Common\AppResourceProvider.h" />
+    <ClInclude Include="..\CalcViewModel\Common\Automation\NarratorAnnouncement.h" />
+    <ClInclude Include="..\CalcViewModel\Common\Automation\NarratorNotifier.h" />
+    <ClInclude Include="..\CalcViewModel\Common\BitLength.h" />
+    <ClInclude Include="..\CalcViewModel\Common\CalculatorButtonPressedEventArgs.h" />
+    <ClInclude Include="..\CalcViewModel\Common\CalculatorButtonUser.h" />
+    <ClInclude Include="..\CalcViewModel\Common\CalculatorDisplay.h" />
+    <ClInclude Include="..\CalcViewModel\Common\CopyPasteManager.h" />
+    <ClInclude Include="..\CalcViewModel\Common\DateCalculator.h" />
+    <ClInclude Include="..\CalcViewModel\Common\DelegateCommand.h" />
+    <ClInclude Include="..\CalcViewModel\Common\DisplayExpressionToken.h" />
+    <ClInclude Include="..\CalcViewModel\Common\EngineResourceProvider.h" />
+    <ClInclude Include="..\CalcViewModel\Common\ExpressionCommandDeserializer.h" />
+    <ClInclude Include="..\CalcViewModel\Common\ExpressionCommandSerializer.h" />
+    <ClInclude Include="..\CalcViewModel\Common\LocalizationService.h" />
+    <ClInclude Include="..\CalcViewModel\Common\LocalizationSettings.h" />
+    <ClInclude Include="..\CalcViewModel\Common\LocalizationStringUtil.h" />
+    <ClInclude Include="..\CalcViewModel\Common\MyVirtualKey.h" />
+    <ClInclude Include="..\CalcViewModel\Common\NavCategory.h" />
+    <ClInclude Include="..\CalcViewModel\Common\NetworkManager.h" />
+    <ClInclude Include="..\CalcViewModel\Common\NumberBase.h" />
+    <ClInclude Include="..\CalcViewModel\Common\RadixType.h" />
+    <ClInclude Include="..\CalcViewModel\Common\TraceLogger.h" />
+    <ClInclude Include="..\CalcViewModel\Common\Utils.h" />
+    <ClInclude Include="..\CalcViewModel\DataLoaders\CurrencyDataLoader.h" />
+    <ClInclude Include="..\CalcViewModel\DataLoaders\CurrencyHttpClient.h" />
+    <ClInclude Include="..\CalcViewModel\DataLoaders\ICurrencyHttpClient.h" />
+    <ClInclude Include="..\CalcViewModel\DataLoaders\UnitConverterDataConstants.h" />
+    <ClInclude Include="..\CalcViewModel\DataLoaders\UnitConverterDataLoader.h" />
+    <ClInclude Include="..\CalcViewModel\DateCalculatorViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\GraphingCalculatorEnums.h" />
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\EquationViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\GraphingCalculatorViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\VariableViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\GraphingSettingsViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\HistoryItemViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\HistoryViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\MemoryItemViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\pch.h" />
+    <ClInclude Include="..\CalcViewModel\StandardCalculatorViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\targetver.h" />
+    <ClInclude Include="..\CalcViewModel\UnitConverterViewModel.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\CalcViewModel\ApplicationViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\AppResourceProvider.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\Automation\NarratorAnnouncement.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\Automation\NarratorNotifier.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\CalculatorButtonPressedEventArgs.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\CalculatorDisplay.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\CopyPasteManager.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\DateCalculator.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\EngineResourceProvider.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\ExpressionCommandDeserializer.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\ExpressionCommandSerializer.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\LocalizationService.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\NavCategory.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\NetworkManager.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\RadixType.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\TraceLogger.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\Utils.cpp" />
+    <ClCompile Include="..\CalcViewModel\DataLoaders\CurrencyDataLoader.cpp" />
+    <ClCompile Include="..\CalcViewModel\DataLoaders\CurrencyHttpClient.cpp" />
+    <ClCompile Include="..\CalcViewModel\DataLoaders\UnitConverterDataLoader.cpp" />
+    <ClCompile Include="..\CalcViewModel\DateCalculatorViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\GraphingCalculator\EquationViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\GraphingCalculator\GraphingCalculatorViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\GraphingCalculator\GraphingSettingsViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\HistoryItemViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\HistoryViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\MemoryItemViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\StandardCalculatorViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\UnitConverterViewModel.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CalcManager\CalcManager.vcxproj">
+      <Project>{311e866d-8b93-4609-a691-265941fee101}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\GraphControl\GraphControl.vcxproj">
+      <Project>{e727a92b-f149-492c-8117-c039a298719b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\TraceLogging\TraceLogging.vcxproj">
+      <Project>{fc81ff41-02cd-4cd9-9bc5-45a1e39ac6ed}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemDefinitionGroup Condition="!Exists('..\CalcViewModel\DataLoaders\DataLoaderConstants.h')">
+    <ClCompile>
+      <AdditionalOptions>/DUSE_MOCK_DATA %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Choose>
+    <When Condition="Exists('..\CalcViewModel\DataLoaders\DataLoaderConstants.h')">
+      <ItemGroup>
+        <ClInclude Include="..\CalcViewModel\DataLoaders\DataLoaderConstants.h" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <ClInclude Include="..\CalcViewModel\DataLoaders\DataLoaderMockConstants.h" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <None Include="..\CalcViewModel\DataLoaders\DefaultFromToCurrency.json" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/CalcViewModelCopyForUT/CalcViewModelCopyForUT.vcxproj.filters
+++ b/src/CalcViewModelCopyForUT/CalcViewModelCopyForUT.vcxproj.filters
@@ -1,0 +1,217 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tga;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Common">
+      <UniqueIdentifier>{2c2762e9-7673-4c4e-bf31-9513125dfc00}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Common\Automation">
+      <UniqueIdentifier>{8f48b19f-14df-421f-bcc6-ef908f9dcff0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="DataLoaders">
+      <UniqueIdentifier>{6811c769-d698-4add-b477-794316d39c66}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="GraphingCalculator">
+      <UniqueIdentifier>{da163ad4-d001-45eb-b4b3-6e9e17d22077}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\CalcViewModel\Common\AppResourceProvider.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\Automation\NarratorAnnouncement.cpp">
+      <Filter>Common\Automation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\Automation\NarratorNotifier.cpp">
+      <Filter>Common\Automation</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\ApplicationViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\DateCalculatorViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\HistoryItemViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\HistoryViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\MemoryItemViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\pch.cpp" />
+    <ClCompile Include="..\CalcViewModel\StandardCalculatorViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\UnitConverterViewModel.cpp" />
+    <ClCompile Include="..\CalcViewModel\Common\Utils.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\CalculatorButtonPressedEventArgs.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\CalculatorDisplay.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\CopyPasteManager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\DateCalculator.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\EngineResourceProvider.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\ExpressionCommandDeserializer.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\ExpressionCommandSerializer.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\LocalizationService.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\NavCategory.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\NetworkManager.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\TraceLogger.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\DataLoaders\CurrencyDataLoader.cpp">
+      <Filter>DataLoaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\DataLoaders\CurrencyHttpClient.cpp">
+      <Filter>DataLoaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\DataLoaders\UnitConverterDataLoader.cpp">
+      <Filter>DataLoaders</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\GraphingCalculator\EquationViewModel.cpp">
+      <Filter>GraphingCalculator</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\GraphingCalculator\GraphingCalculatorViewModel.cpp">
+      <Filter>GraphingCalculator</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\GraphingCalculator\GraphingSettingsViewModel.cpp">
+      <Filter>GraphingCalculator</Filter>
+    </ClCompile>
+    <ClCompile Include="..\CalcViewModel\Common\RadixType.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\CalcViewModel\Common\AppResourceProvider.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\Automation\NarratorAnnouncement.h">
+      <Filter>Common\Automation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\Automation\NarratorNotifier.h">
+      <Filter>Common\Automation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\ApplicationViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\DateCalculatorViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\HistoryItemViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\HistoryViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\MemoryItemViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\pch.h" />
+    <ClInclude Include="..\CalcViewModel\StandardCalculatorViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\targetver.h" />
+    <ClInclude Include="..\CalcViewModel\UnitConverterViewModel.h" />
+    <ClInclude Include="..\CalcViewModel\Common\Utils.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\BitLength.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\CalculatorButtonPressedEventArgs.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\CalculatorButtonUser.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\CalculatorDisplay.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\CopyPasteManager.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\DateCalculator.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\DelegateCommand.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\DisplayExpressionToken.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\EngineResourceProvider.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\ExpressionCommandDeserializer.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\ExpressionCommandSerializer.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\GraphingCalculatorEnums.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\LocalizationService.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\LocalizationSettings.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\LocalizationStringUtil.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\MyVirtualKey.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\NavCategory.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\NetworkManager.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\NumberBase.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\TraceLogger.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\DataLoaders\CurrencyDataLoader.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\DataLoaders\CurrencyHttpClient.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\DataLoaders\DataLoaderMockConstants.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\DataLoaders\ICurrencyHttpClient.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\DataLoaders\UnitConverterDataConstants.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\DataLoaders\UnitConverterDataLoader.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\EquationViewModel.h">
+      <Filter>GraphingCalculator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\GraphingCalculatorViewModel.h">
+      <Filter>GraphingCalculator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\GraphingSettingsViewModel.h">
+      <Filter>GraphingCalculator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\GraphingCalculator\VariableViewModel.h">
+      <Filter>GraphingCalculator</Filter>
+    </ClInclude>
+    <ClInclude Include="..\CalcViewModel\Common\RadixType.h" />
+    <ClInclude Include="..\CalcViewModel\Common\AlwaysSelectedCollectionView.h">
+      <Filter>Common</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\CalcViewModel\DataLoaders\DefaultFromToCurrency.json">
+      <Filter>DataLoaders</Filter>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Calculator.sln
+++ b/src/Calculator.sln
@@ -27,6 +27,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TraceLogging", "TraceLoggin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Calculator", "Calculator\Calculator.csproj", "{3B773403-B0D6-4F9A-948E-512A7A5FB315}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CalcViewModelCopyForUT", "CalcViewModelCopyForUT\CalcViewModelCopyForUT.vcxproj", "{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -191,6 +193,20 @@ Global
 		{3B773403-B0D6-4F9A-948E-512A7A5FB315}.Release|x86.ActiveCfg = Release|x86
 		{3B773403-B0D6-4F9A-948E-512A7A5FB315}.Release|x86.Build.0 = Release|x86
 		{3B773403-B0D6-4F9A-948E-512A7A5FB315}.Release|x86.Deploy.0 = Release|x86
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|ARM.ActiveCfg = Debug|ARM
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|ARM.Build.0 = Debug|ARM
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|x64.ActiveCfg = Debug|x64
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|x64.Build.0 = Debug|x64
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|x86.ActiveCfg = Debug|Win32
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Debug|x86.Build.0 = Debug|Win32
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|ARM.ActiveCfg = Release|ARM
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|ARM.Build.0 = Release|ARM
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|ARM64.ActiveCfg = Release|Win32
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|x64.ActiveCfg = Release|x64
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|x64.Build.0 = Release|x64
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|x86.ActiveCfg = Release|Win32
+		{CC9B4FA7-D746-4F52-9401-0AD1B4D6B16D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -280,8 +280,8 @@
     <ProjectReference Include="..\CalcManager\CalcManager.vcxproj">
       <Project>{311e866d-8b93-4609-a691-265941fee101}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\CalcViewModel\CalcViewModel.vcxproj">
-      <Project>{90e9761d-9262-4773-942d-caeae75d7140}</Project>
+    <ProjectReference Include="..\CalcViewModelCopyForUT\CalcViewModelCopyForUT.vcxproj">
+      <Project>{cc9b4fa7-d746-4f52-9401-0ad1b4d6b16d}</Project>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/CalculatorUnitTests/LocalizationSettingsUnitTests.cpp
+++ b/src/CalculatorUnitTests/LocalizationSettingsUnitTests.cpp
@@ -57,13 +57,13 @@ namespace CalculatorUnitTests
 
         TEST_METHOD(TestIsEnUsDigit)
         {
-            auto& settings = LocalizationSettings::GetInstance();
-            VERIFY_IS_FALSE(settings.IsEnUsDigit(L'/'));
-            VERIFY_IS_TRUE(settings.IsEnUsDigit(L'0'));
-            VERIFY_IS_TRUE(settings.IsEnUsDigit(L'1'));
-            VERIFY_IS_TRUE(settings.IsEnUsDigit(L'8'));
-            VERIFY_IS_TRUE(settings.IsEnUsDigit(L'9'));
-            VERIFY_IS_FALSE(settings.IsEnUsDigit(L':'));
+            auto settings = LocalizationSettings::GetInstance();
+            VERIFY_IS_FALSE(settings->IsEnUsDigit(L'/'));
+            VERIFY_IS_TRUE(settings->IsEnUsDigit(L'0'));
+            VERIFY_IS_TRUE(settings->IsEnUsDigit(L'1'));
+            VERIFY_IS_TRUE(settings->IsEnUsDigit(L'8'));
+            VERIFY_IS_TRUE(settings->IsEnUsDigit(L'9'));
+            VERIFY_IS_FALSE(settings->IsEnUsDigit(L':'));
         }
 
         TEST_METHOD(TestIsLocalizedDigit)


### PR DESCRIPTION
**Description of the changes:**
- Created a static library project CalcViewModelCopyForUT which added all the files in CalcViewModel as link without physically copying the files to the project directory.
- CalculatorUnitTests project will refer to CalcViewModelCopyForUT instead of CalcViewModel as the static library will open more information to other projects than the Windows Runtime Component DLL.

**How changes were validated:**
Passed build and all 298 Unit Tests.