### PR TITLE
fixes up the crash of type casting

### DIFF
--- a/src/Calculator/Common/KeyboardShortcuManager.cs
+++ b/src/Calculator/Common/KeyboardShortcuManager.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using CalculatorApp.ViewModel;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using Windows.Foundation.Collections;
@@ -621,7 +622,7 @@ namespace CalculatorApp
                     var categoryName = AppResourceProvider.GetInstance().GetResourceString("DateCalculationModeText");
                     appViewModel.CategoryName = categoryName;
 
-                    var menuItems = ((IObservableVector<object>)navView.MenuItemsSource);
+                    var menuItems = ((ObservableCollection<object>)navView.MenuItemsSource);
                     var flatIndex = NavCategory.GetFlatIndex(ViewMode.Date);
                     navView.SelectedItem = menuItems[flatIndex];
                     return;
@@ -710,7 +711,7 @@ namespace CalculatorApp
                             {
                                 var navView = item as MUXC.NavigationView; // CSHARP_MIGRATION: TODO: check if this line is still needed
 
-                                var menuItems = ((IObservableVector<object>)navView.MenuItemsSource);
+                                var menuItems = ((ObservableCollection<object>)navView.MenuItemsSource);
                                 if (menuItems != null)
                                 {
                                     var vm = (navView.DataContext as ApplicationViewModel);


### PR DESCRIPTION
## Fixes up the crash of type casting


### Description of the changes:
- casting navView.MenuItemsSource to IObservableVector<object> fails with exception
- cast to ObservableCollection<object>


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build passed.
- Problem resolved.
- Functionalities are back.
- CI pipeline is not applicable at current stage.

