### PR TITLE
Improve clarity of math expressions in history for Standard Calculato…

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -265,6 +265,13 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
                 if (!m_bError)
                 {
                     DisplayNum();
+                    if (!m_fPrecedence)
+                    {
+
+                        wstring groupedString = GroupDigitsPerRadix(m_numberString, m_radix);
+                        m_HistoryCollector.CompleteEquation(groupedString);
+                        m_HistoryCollector.AddOpndToHistory(m_numberString, m_currentVal);
+                    }
                 }
 
                 if ((m_precedenceOpCount != 0) && (m_nPrecOp[m_precedenceOpCount - 1]))

--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -78,7 +78,7 @@ namespace CalculatorUITests
             page.StandardOperators.NumberPad.Num2Button.Click();
             page.StandardOperators.MinusButton.Click();
             Assert.AreEqual("4", page.CalculatorResults.GetCalculatorResultText()); //verifies addition
-            Assert.AreEqual("2 + 2 Minus (", page.CalculatorResults.GetCalculatorExpressionText()); //verifies - button
+            Assert.AreEqual("4 Minus (", page.CalculatorResults.GetCalculatorExpressionText()); //verifies - button
             page.StandardOperators.NumberPad.Num3Button.Click();
             Assert.AreEqual("3", page.CalculatorResults.GetCalculatorResultText()); //verifies 3 button
             page.StandardOperators.EqualButton.Click();
@@ -102,12 +102,12 @@ namespace CalculatorUITests
             Assert.AreEqual("5", page.CalculatorResults.GetCalculatorResultText()); //verifies 5 button
             page.StandardOperators.DivideButton.Click();
             Assert.AreEqual("20", page.CalculatorResults.GetCalculatorResultText()); //verifies multiplication
-            Assert.AreEqual("4 × 5 ÷", page.CalculatorResults.GetCalculatorExpressionText()); //verifies ÷ button
+            Assert.AreEqual("20 ÷", page.CalculatorResults.GetCalculatorExpressionText()); //verifies ÷ button
             page.StandardOperators.NumberPad.Num6Button.Click();
             Assert.AreEqual("6", page.CalculatorResults.GetCalculatorResultText()); //verifies 6 button
             page.StandardOperators.EqualButton.Click();
             Assert.AreEqual("3.333333333333333", page.CalculatorResults.GetCalculatorResultText()); //verifies division
-            Assert.AreEqual("4 × 5 ÷ 6=", page.CalculatorResults.GetCalculatorExpressionText()); //verifies = button
+            Assert.AreEqual("20 ÷ 6=", page.CalculatorResults.GetCalculatorExpressionText()); //verifies = button
         }
 
         [TestMethod]
@@ -173,11 +173,15 @@ namespace CalculatorUITests
             page.HistoryPanel.HistoryButton.Click();
             var historyFlyoutItems = page.HistoryPanel.GetAllHistoryFlyoutListViewItems();
             Assert.IsTrue(historyFlyoutItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
-            Assert.IsTrue(historyFlyoutItems[0].GetExpression().Equals("4   ×   5   ÷   6 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
+            Assert.IsTrue(historyFlyoutItems[0].GetExpression().Equals("20   ÷   6 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
+            Assert.IsTrue(historyFlyoutItems[1].GetValue().Equals("20", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
+            Assert.IsTrue(historyFlyoutItems[1].GetExpression().Equals("4   ×   5 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
             page.HistoryPanel.ResizeWindowToDisplayHistoryLabel();
             var historyItems = page.HistoryPanel.GetAllHistoryListViewItems();
-            Assert.IsTrue(historyItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase));
-            Assert.IsTrue(historyItems[0].GetExpression().Equals("4   ×   5   ÷   6 =", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyFlyoutItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
+            Assert.IsTrue(historyFlyoutItems[0].GetExpression().Equals("20   ÷   6 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
+            Assert.IsTrue(historyFlyoutItems[1].GetValue().Equals("20", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
+            Assert.IsTrue(historyFlyoutItems[1].GetExpression().Equals("4   ×   5 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button
             page.HistoryPanel.ClearHistoryButton.Click();
             Assert.IsNotNull(WinAppDriver.Instance.CalculatorSession.FindElementByAccessibilityId("HistoryEmpty")); //verifies the History panel's clear history button
         }
@@ -251,7 +255,7 @@ namespace CalculatorUITests
             CalculatorApp.Window.SendKeys("2");
             CalculatorApp.Window.SendKeys(Keys.Subtract);
             Assert.AreEqual("4", page.CalculatorResults.GetCalculatorResultText()); //verifies addition
-            Assert.AreEqual("2 + 2 Minus (", page.CalculatorResults.GetCalculatorExpressionText()); //verifies using subtraction key
+            Assert.AreEqual("4 Minus (", page.CalculatorResults.GetCalculatorExpressionText()); //verifies using subtraction key
             CalculatorApp.Window.SendKeys("3");
             Assert.AreEqual("3", page.CalculatorResults.GetCalculatorResultText()); //verifies using 3 key
             page.StandardOperators.EqualButton.Click();
@@ -278,12 +282,12 @@ namespace CalculatorUITests
             Assert.AreEqual("5", page.CalculatorResults.GetCalculatorResultText()); //verifies using 5 key
             CalculatorApp.Window.SendKeys(Keys.Divide);
             Assert.AreEqual("20", page.CalculatorResults.GetCalculatorResultText()); //verifies multiplication
-            Assert.AreEqual("4 × 5 ÷", page.CalculatorResults.GetCalculatorExpressionText()); //verifies using divide key
+            Assert.AreEqual("20 ÷", page.CalculatorResults.GetCalculatorExpressionText()); //verifies using divide key
             CalculatorApp.Window.SendKeys("6");
             Assert.AreEqual("6", page.CalculatorResults.GetCalculatorResultText()); //verifies using 6 key
             CalculatorApp.Window.SendKeys(Keys.Equal);
             Assert.AreEqual("3.333333333333333", page.CalculatorResults.GetCalculatorResultText()); //verifies division
-            Assert.AreEqual("4 × 5 ÷ 6=", page.CalculatorResults.GetCalculatorExpressionText()); //verifies equal key
+            Assert.AreEqual("20 ÷ 6=", page.CalculatorResults.GetCalculatorExpressionText()); //verifies equal key
         }
 
         [TestMethod]
@@ -378,13 +382,18 @@ namespace CalculatorUITests
             page.HistoryPanel.ResizeWindowToDisplayHistoryButton();
             CalculatorApp.Window.SendKeys(Keys.Control + "h" + Keys.Control);
             var historyFlyoutItems = page.HistoryPanel.GetAllHistoryFlyoutListViewItems();
-            var historyExpression = Regex.Replace(historyFlyoutItems[0].GetExpression(), @"\s", string.Empty);
+            var historyExpression0 = Regex.Replace(historyFlyoutItems[0].GetExpression(), @"\s", string.Empty);
+            var historyExpression1 = Regex.Replace(historyFlyoutItems[1].GetExpression(), @"\s", string.Empty);
             Assert.IsTrue(historyFlyoutItems[0].GetValue().Equals("10", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
-            Assert.IsTrue(historyExpression.Equals("4×5÷2=", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            Assert.IsTrue(historyExpression0.Equals("20÷2=", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            Assert.IsTrue(historyFlyoutItems[1].GetValue().Equals("20", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            Assert.IsTrue(historyExpression1.Equals("4×5=", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
             page.HistoryPanel.ResizeWindowToDisplayHistoryLabel();
             var historyItems = page.HistoryPanel.GetAllHistoryListViewItems();
             Assert.IsTrue(historyItems[0].GetValue().Equals("10", StringComparison.InvariantCultureIgnoreCase));
-            Assert.IsTrue(historyExpression.Equals("4×5÷2=", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems[1].GetValue().Equals("20", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyExpression0.Equals("20÷2=", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            Assert.IsTrue(historyExpression1.Equals("4×5=", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
             CalculatorApp.Window.SendKeys(Keys.Shift + Keys.Control + "d" + Keys.Control + Keys.Shift);
             Assert.IsNotNull(WinAppDriver.Instance.CalculatorSession.FindElementByAccessibilityId("HistoryEmpty")); //verifies the History panel's clear history button hotkeys
         }
@@ -604,7 +613,7 @@ namespace CalculatorUITests
             CalculatorApp.Window.SendKeys("6");
             page.StandardOperators.ClearEntryButton.Click();
             Assert.AreEqual("0", page.CalculatorResults.GetCalculatorResultText());
-            Assert.AreEqual("3 + 9 Minus (", page.CalculatorResults.GetCalculatorExpressionText());
+            Assert.AreEqual("12 Minus (", page.CalculatorResults.GetCalculatorExpressionText());
 
             //Verify Clear
             page.StandardOperators.NumberPad.Input(6);

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -200,6 +200,8 @@ namespace CalculatorManagerTest
         TEST_METHOD(CalculatorManagerTestBinaryOperatorReceived_Multiple);
         TEST_METHOD(CalculatorManagerTestBinaryOperatorReceived_LongInput);
 
+        TEST_METHOD(CalculatorManagerTestStandardOrderOfOperations);
+
         TEST_METHOD_CLEANUP(Cleanup);
 
     private:
@@ -343,7 +345,7 @@ namespace CalculatorManagerTest
 
         Command commands8[] = { Command::Command9,     Command::CommandMUL, Command::Command6,   Command::CommandSUB,
                                 Command::CommandCENTR, Command::Command8,   Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"46", L"9 \x00D7 6 - 8=", commands8);
+        TestDriver::Test(L"46", L"54 - 8=", commands8);
 
         Command commands9[] = { Command::Command6, Command::CommandMUL, Command::Command6, Command::CommandPERCENT, Command::CommandEQU, Command::CommandNULL };
         TestDriver::Test(L"0.36", L"6 \x00D7 0.06=", commands9);
@@ -374,7 +376,7 @@ namespace CalculatorManagerTest
 
         Command commands17[] = { Command::Command1,     Command::Command2, Command::CommandADD, Command::Command5,
                                  Command::CommandCENTR, Command::Command2, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"14", L"12 + 2 + ", commands17);
+        TestDriver::Test(L"14", L"14 + ", commands17);
 
         Command commands18[] = { Command::Command1, Command::Command0, Command::Command0, Command::CommandSIGN, Command::CommandREC, Command::CommandNULL };
         TestDriver::Test(L"-0.01", L"1/(-100)", commands18);
@@ -387,11 +389,11 @@ namespace CalculatorManagerTest
         TestDriver::Test(L"0", L"", commands20);
 
         Command commands21[] = { Command::Command4, Command::CommandSQRT, Command::CommandSUB, Command::Command2, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"0", L"\x221A(4) - 2 + ", commands21);
+        TestDriver::Test(L"0", L"0 + ", commands21);
 
         Command commands22[] = { Command::Command1,   Command::Command0, Command::Command2, Command::Command4,   Command::CommandSQRT,
                                  Command::CommandSUB, Command::Command3, Command::Command2, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"0", L"\x221A(1024) - 32 + ", commands22);
+        TestDriver::Test(L"0", L"0 + ", commands22);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestScientific()
@@ -467,14 +469,14 @@ namespace CalculatorManagerTest
         TestDriver::Test(L"0", L"", commands20, true, true);
 
         Command commands21[] = { Command::Command4, Command::CommandSQRT, Command::CommandSUB, Command::Command2, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"0", L"\x221A(4) - 2 + ", commands21);
+        TestDriver::Test(L"0", L"\x221A(4) - 2 + ", commands21, true, true);
 
         Command commands22[] = { Command::Command0, Command::CommandSQRT, Command::CommandNULL };
-        TestDriver::Test(L"0", L"\x221A(0)", commands22);
+        TestDriver::Test(L"0", L"\x221A(0)", commands22, true, true);
 
         Command commands23[] = { Command::Command1,   Command::Command0, Command::Command2, Command::Command4,   Command::CommandSQRT,
                                  Command::CommandSUB, Command::Command3, Command::Command2, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"0", L"\x221A(1024) - 32 + ", commands23);
+        TestDriver::Test(L"0", L"\x221A(1024) - 32 + ", commands23, true, true);
 
         Command commands24[] = { Command::Command2,    Command::Command5,    Command::Command7,   Command::CommandSQRT,
                                  Command::CommandSQRT, Command::CommandSQRT, Command::CommandNULL };
@@ -533,10 +535,10 @@ namespace CalculatorManagerTest
         TestDriver::Test(L"7.389056098930650227230427460575", L"e^(2)", commands16, true, true);
 
         Command commands17[] = { Command::Command5, Command::CommandPWR, Command::Command0, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"1", L"5 ^ 0 + ", commands17);
+        TestDriver::Test(L"1", L"5 ^ 0 + ", commands17, true, true);
 
         Command commands18[] = { Command::Command0, Command::CommandPWR, Command::Command0, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"1", L"0 ^ 0 + ", commands18);
+        TestDriver::Test(L"1", L"0 ^ 0 + ", commands18, true, true);
 
         Command commands19[] = { Command::Command2, Command::Command7,   Command::CommandSIGN, Command::CommandROOT,
                                  Command::Command3, Command::CommandADD, Command::CommandNULL };
@@ -593,28 +595,28 @@ namespace CalculatorManagerTest
         TestDriver::Test(L"0.54930614433405484569762261846126", L"coth\x207B\x00B9(2)", commands34, true, true);
 
         Command commands35[] = { Command::Command8, Command::CommandPOW2, Command::CommandNULL };
-        TestDriver::Test(L"256", L"2^(8)", commands35);
+        TestDriver::Test(L"256", L"2^(8)", commands35, true, true);
 
         Command commands36[] = { Command::CommandRand, Command::CommandCeil, Command::CommandNULL };
-        TestDriver::Test(L"1", L"N/A", commands36);
+        TestDriver::Test(L"1", L"N/A", commands36, true, true);
 
         Command commands37[] = { Command::CommandRand, Command::CommandFloor, Command::CommandNULL };
-        TestDriver::Test(L"0", L"N/A", commands37);
+        TestDriver::Test(L"0", L"N/A", commands37, true, true);
 
         Command commands38[] = { Command::CommandRand, Command::CommandSIGN, Command::CommandCeil, Command::CommandNULL };
-        TestDriver::Test(L"0", L"N/A", commands38);
+        TestDriver::Test(L"0", L"N/A", commands38, true, true);
 
         Command commands39[] = { Command::CommandRand, Command::CommandSIGN, Command::CommandFloor, Command::CommandNULL };
-        TestDriver::Test(L"-1", L"N/A", commands39);
+        TestDriver::Test(L"-1", L"N/A", commands39, true, true);
 
         Command commands40[] = { Command::Command3, Command::CommandPNT, Command::Command8, Command::CommandFloor, Command::CommandNULL };
-        TestDriver::Test(L"3", L"floor(3.8)", commands40);
+        TestDriver::Test(L"3", L"floor(3.8)", commands40, true, true);
 
         Command commands41[] = { Command::Command3, Command::CommandPNT, Command::Command8, Command::CommandCeil, Command::CommandNULL };
-        TestDriver::Test(L"4", L"ceil(3.8)", commands41);
+        TestDriver::Test(L"4", L"ceil(3.8)", commands41, true, true);
 
         Command commands42[] = { Command::Command5, Command::CommandLogBaseY, Command::Command3, Command::CommandADD, Command::CommandNULL };
-        TestDriver::Test(L"1.464973520717927", L"5 log base 3 + ", commands42);
+        TestDriver::Test(L"1.4649735207179271671970404076786", L"5 log base 3 + ", commands42, true, true);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestScientificParenthesis()
@@ -1078,6 +1080,81 @@ namespace CalculatorManagerTest
 
          // Verify BinaryOperatorReceived
          VERIFY_ARE_EQUAL(4, pCalculatorDisplay->GetBinaryOperatorReceivedCallCount());
+     }
+
+     void CalculatorManagerTest::CalculatorManagerTestStandardOrderOfOperations()
+     {
+         Command commands1[] = { Command::Command1, Command::CommandREC, Command::CommandNULL };
+         TestDriver::Test(L"1", L"1/(1)", commands1);
+
+         Command commands2[] = { Command::Command4, Command::CommandSQRT, Command::CommandNULL };
+         TestDriver::Test(L"2", L"\x221A(4)", commands2);
+
+         Command commands3[] = { Command::Command1, Command::CommandADD, Command::Command4, Command::CommandSQRT, Command::CommandNULL };
+         TestDriver::Test(L"2", L"1 + \x221A(4)", commands3);
+
+         Command commands4[] = { Command::Command1, Command::CommandADD, Command::Command4, Command::CommandSQRT, Command::CommandSUB, Command::CommandNULL };
+         TestDriver::Test(L"3", L"3 - ", commands4);
+
+         Command commands5[] = { Command::Command2, Command::CommandMUL, Command::Command4, Command::CommandREC, Command::CommandNULL };
+         TestDriver::Test(L"0.25", L"2 \x00D7 1/(4)", commands5);
+
+         Command commands6[] = { Command::Command5, Command::CommandDIV, Command::Command6, Command::CommandPERCENT, Command::CommandNULL};
+         TestDriver::Test(L"0.06", L"5 \x00F7 0.06", commands6);
+
+         Command commands7[] = { Command::Command4, Command::CommandSQRT, Command::CommandSUB, Command::CommandNULL };
+         TestDriver::Test(L"2", L"\x221A(4) - ", commands7);
+
+         Command commands8[] = { Command::Command7, Command::CommandSQR, Command::CommandDIV, Command::CommandNULL };
+         TestDriver::Test(L"49", L"sqr(7) \x00F7 ", commands8);
+
+         Command commands9[] = { Command::Command8, Command::CommandSQR, Command::CommandSQRT, Command::CommandNULL };
+         TestDriver::Test(L"8", L"\x221A(sqr(8))", commands9);
+
+         Command commands10[] = { Command::Command1, Command::Command0, Command::CommandADD, Command::Command2, Command::CommandSUB, Command::CommandNULL };
+         TestDriver::Test(L"12", L"12 - ", commands10);
+
+         Command commands11[] = { Command::Command3, Command::CommandMUL, Command::Command4, Command::CommandDIV, Command::CommandNULL };
+         TestDriver::Test(L"12", L"12 \x00F7 ", commands11);
+
+         Command commands12[] = { Command::Command6, Command::CommandDIV, Command::Command3, Command::CommandSUB, Command::CommandADD, Command::CommandNULL };
+         TestDriver::Test(L"2", L"2 + ", commands12);
+
+         Command commands13[] = { Command::Command7, Command::CommandSUB, Command::Command4, Command::CommandDIV, Command::CommandMUL, Command::CommandNULL };
+         TestDriver::Test(L"3", L"3 \x00D7 ", commands13);
+
+         Command commands14[] = { Command::Command8, Command::CommandMUL, Command::Command2, Command::CommandADD, Command::CommandSQRT, Command::CommandNULL };
+         TestDriver::Test(L"4", L"16 + \x221A(16)", commands14);
+
+         Command commands15[] = { Command::Command9, Command::CommandADD, Command::Command0, Command::CommandMUL, Command::CommandSIGN, Command::CommandNULL };
+         TestDriver::Test(L"-9", L"9 \x00D7 negate(9)", commands15);
+
+         Command commands16[] = { Command::Command9, Command::CommandSIGN, Command::Command0, Command::CommandADD, Command::CommandMUL, Command::CommandNULL };
+         TestDriver::Test(L"-90", L"-90 \x00D7 ", commands16);
+
+         Command commands17[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandEQU, Command::CommandNULL };
+         TestDriver::Test(L"3", L"1 + 2=", commands17);
+
+         Command commands18[] = { Command::Command2, Command::Command0, Command::CommandMUL, Command::Command0, Command::Command2, Command::CommandEQU, Command::CommandNULL };
+         TestDriver::Test(L"40", L"20 \x00D7 2=", commands18);
+
+         Command commands19[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandADD, Command::CommandBACK, Command::CommandNULL };
+         TestDriver::Test(L"3", L"3 + ", commands19);
+
+         Command commands20[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandADD, Command::CommandCLEAR, Command::CommandNULL };
+         TestDriver::Test(L"0", L"", commands20);
+
+         Command commands21[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandADD, Command::CommandCENTR, Command::CommandNULL };
+         TestDriver::Test(L"0", L"3 + ", commands21);
+
+         Command commands22[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandCLEAR, Command::CommandNULL };
+         TestDriver::Test(L"0", L"", commands22);
+
+         Command commands23[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandCENTR, Command::CommandNULL };
+         TestDriver::Test(L"0", L"1 + ", commands23);
+
+         Command commands24[] = { Command::Command1, Command::CommandMUL, Command::Command2, Command::CommandMUL, Command::Command3, Command::CommandMUL, Command::Command4, Command::CommandMUL, Command::Command5, Command::CommandMUL, Command::CommandNULL };
+         TestDriver::Test(L"120", L"120 \x00D7 ", commands24);
      }
 
 } /* namespace CalculationManagerUnitTests */

--- a/src/CalculatorUnitTests/HistoryTests.cpp
+++ b/src/CalculatorUnitTests/HistoryTests.cpp
@@ -35,6 +35,30 @@ namespace CalculatorFunctionalTests
         TEST_METHOD(TestDisplayValueAutomationNames);
         TEST_METHOD(TestRadixAutomationName);
         TEST_METHOD(TestHistoryEmpty);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_1);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_2);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_3);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_4);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_5);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_6);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_7);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_8);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_9);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_10);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_11);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_12);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_13);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_14);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_15);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_16);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_17);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_18);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_19);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_20);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_21);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_22);
+        TEST_METHOD(TestHistoryStandardOrderOfOperations_23);
+        TEST_METHOD(TestHistoryStandardOrderOfOperationsMultiple);
 
     private:
         HistoryViewModel ^ m_historyViewModel;
@@ -283,14 +307,14 @@ namespace CalculatorFunctionalTests
             m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
             m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command5));
             m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
-            VERIFY_ARE_EQUAL(StringReference(L"14"), m_standardViewModel->DisplayValue);
+            VERIFY_ARE_EQUAL(StringReference(L"11"), m_standardViewModel->DisplayValue);
             historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemsCount - 1));
             m_standardViewModel->SelectHistoryItem(historyItem);
-            VERIFY_ARE_EQUAL(StringReference(L"9"), m_standardViewModel->DisplayValue);
+            VERIFY_ARE_EQUAL(StringReference(L"6"), m_standardViewModel->DisplayValue);
 
             historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemsCount - 2));
             m_standardViewModel->SelectHistoryItem(historyItem);
-            VERIFY_ARE_EQUAL(StringReference(L"14"), m_standardViewModel->DisplayValue);
+            VERIFY_ARE_EQUAL(StringReference(L"9"), m_standardViewModel->DisplayValue);
             Cleanup();
         }
 
@@ -362,6 +386,171 @@ namespace CalculatorFunctionalTests
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemsCount);
             Cleanup();
         }
+
+        void HistoryStandardOrderOfOperationsHelper(String ^ expectedResult, String ^ expectedExpression, Command testCommands[])
+        {
+            Initialize();
+            int initialSize = m_historyViewModel->ItemsCount;
+            Command* currentCommand = testCommands;
+            while (*currentCommand != Command::CommandNULL)
+            {
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(*currentCommand++));
+            }
+            int sizeAfterCommandsAdd = m_historyViewModel->ItemsCount;
+            if (expectedResult->IsEmpty())
+            {
+                VERIFY_ARE_EQUAL(initialSize, sizeAfterCommandsAdd);
+            }
+            else
+            {
+                auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(0));
+                VERIFY_ARE_EQUAL(initialSize + 1, sizeAfterCommandsAdd);
+                VERIFY_ARE_EQUAL(historyItem->Expression, expectedExpression);
+                VERIFY_ARE_EQUAL(historyItem->Result, expectedResult);
+            }
+            Cleanup();
+        }
+
+        void HistoryStandardOrderOfOperations_1() {
+            Command commands[] = { Command::Command1, Command::CommandREC };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_2() {
+            Command commands[] = { Command::Command4, Command::CommandSQRT };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_3() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command4, Command::CommandSQRT };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_4() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command4, Command::CommandSQRT, Command::CommandSUB };
+            HistoryStandardOrderOfOperationsHelper(L"3", L"1   +   \x221A( 4 ) =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_5() {
+            Command commands[] = { Command::Command2, Command::CommandMUL, Command::Command4, Command::CommandREC };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_6() {
+            Command commands[] = { Command::Command5, Command::CommandDIV, Command::Command6, Command::CommandPERCENT };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_7() {
+            Command commands[] = { Command::Command4, Command::CommandSQRT, Command::CommandSUB };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_8() {
+            Command commands[] = { Command::Command7, Command::CommandSQR, Command::CommandDIV };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_9() {
+            Command commands[] = { Command::Command8, Command::CommandSQR, Command::CommandSQRT };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_10() {
+            Command commands[] = { Command::Command1, Command::Command0, Command::CommandADD, Command::Command2, Command::CommandSUB };
+            HistoryStandardOrderOfOperationsHelper(L"12", L"10   +   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_11() {
+            Command commands[] = { Command::Command3, Command::CommandMUL, Command::Command4, Command::CommandDIV };
+            HistoryStandardOrderOfOperationsHelper(L"12", L"3   \x00D7   4 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_12() {
+            Command commands[] = { Command::Command6, Command::CommandDIV, Command::Command3, Command::CommandSUB, Command::CommandADD };
+            HistoryStandardOrderOfOperationsHelper(L"2", L"6   \x00F7   3 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_13() {
+            Command commands[] = { Command::Command7, Command::CommandSUB, Command::Command4, Command::CommandDIV, Command::CommandMUL };
+            HistoryStandardOrderOfOperationsHelper(L"3", L"7   -   4 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_14() {
+            Command commands[] = { Command::Command8, Command::CommandMUL, Command::Command2, Command::CommandADD, Command::CommandSQRT };
+            HistoryStandardOrderOfOperationsHelper(L"16", L"8   \x00D7   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_15() {
+            Command commands[] = { Command::Command9, Command::CommandADD, Command::Command0, Command::CommandMUL, Command::CommandSIGN };
+            HistoryStandardOrderOfOperationsHelper(L"9", L"9   +   0 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_16() {
+            Command commands[] = { Command::Command9, Command::CommandSIGN, Command::Command0, Command::CommandADD, Command::CommandMUL };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_17() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandEQU };
+            HistoryStandardOrderOfOperationsHelper(L"3", L"1   +   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_18() {
+            Command commands[] = { Command::Command2, Command::Command0, Command::CommandMUL, Command::Command0, Command::Command2, Command::CommandEQU };
+            HistoryStandardOrderOfOperationsHelper(L"40", L"20   \x00D7   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_19() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandADD, Command::CommandBACK };
+            HistoryStandardOrderOfOperationsHelper(L"3", L"1   +   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_20() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandADD, Command::CommandCLEAR };
+            HistoryStandardOrderOfOperationsHelper(L"3", L"1   +   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_21() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandADD, Command::CommandCENTR };
+            HistoryStandardOrderOfOperationsHelper(L"3", L"1   +   2 =", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_22() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandCLEAR };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperations_23() {
+            Command commands[] = { Command::Command1, Command::CommandADD, Command::Command2, Command::CommandCENTR };
+            HistoryStandardOrderOfOperationsHelper(L"", L"", commands);
+        }
+
+        void HistoryStandardOrderOfOperationsMultiple() {
+            Initialize();
+            Command commands[] = { Command::Command1, Command::CommandMUL, Command::Command2, Command::CommandMUL, Command::Command3,   Command::CommandMUL, Command::Command4, Command::CommandMUL, Command::Command5, Command::CommandMUL };
+            int initialSize = m_historyViewModel->ItemsCount;
+            Command* currentCommand = commands;
+            while (*currentCommand != Command::CommandNULL)
+            {
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(*currentCommand++));
+            }
+            int sizeAfterCommandsAdd = m_historyViewModel->ItemsCount;
+            VERIFY_ARE_EQUAL(initialSize + 4, sizeAfterCommandsAdd);
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(0));
+            VERIFY_ARE_EQUAL(historyItem->Expression, L"24   \x00D7   5 =");
+            VERIFY_ARE_EQUAL(historyItem->Result, L"120");
+            historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(1));
+            VERIFY_ARE_EQUAL(historyItem->Expression, L"6   \x00D7   4 =");
+            VERIFY_ARE_EQUAL(historyItem->Result, L"24");
+            historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(2));
+            VERIFY_ARE_EQUAL(historyItem->Expression, L"2   \x00D7   3 =");
+            VERIFY_ARE_EQUAL(historyItem->Result, L"6");
+            historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(3));
+            VERIFY_ARE_EQUAL(historyItem->Expression, L"1   \x00D7   2 =");
+            VERIFY_ARE_EQUAL(historyItem->Result, L"2");
+            Cleanup();
+        }
     };
 
     void HistoryTests::TestHistoryItemAddSingleItem()
@@ -422,5 +611,101 @@ namespace CalculatorFunctionalTests
     void HistoryTests::TestHistoryClearCommandWithEmptyHistory()
     {
         HistoryClearCommandWithEmptyHistory();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_1(){
+        HistoryStandardOrderOfOperations_1();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_2(){
+        HistoryStandardOrderOfOperations_2();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_3(){
+        HistoryStandardOrderOfOperations_3();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_4(){
+        HistoryStandardOrderOfOperations_4();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_5(){
+        HistoryStandardOrderOfOperations_5();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_6(){
+        HistoryStandardOrderOfOperations_6();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_7(){
+        HistoryStandardOrderOfOperations_7();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_8(){
+        HistoryStandardOrderOfOperations_8();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_9(){
+        HistoryStandardOrderOfOperations_9();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_10(){
+        HistoryStandardOrderOfOperations_10();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_11(){
+        HistoryStandardOrderOfOperations_11();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_12(){
+        HistoryStandardOrderOfOperations_12();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_13(){
+        HistoryStandardOrderOfOperations_13();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_14(){
+        HistoryStandardOrderOfOperations_14();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_15(){
+        HistoryStandardOrderOfOperations_15();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_16(){
+        HistoryStandardOrderOfOperations_16();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_17(){
+        HistoryStandardOrderOfOperations_17();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_18(){
+        HistoryStandardOrderOfOperations_18();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_19(){
+        HistoryStandardOrderOfOperations_19();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_20(){
+        HistoryStandardOrderOfOperations_20();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_21(){
+        HistoryStandardOrderOfOperations_21();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_22(){
+        HistoryStandardOrderOfOperations_22();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperations_23(){
+        HistoryStandardOrderOfOperations_23();
+    }
+
+    void HistoryTests::TestHistoryStandardOrderOfOperationsMultiple(){
+        HistoryStandardOrderOfOperationsMultiple();
     }
 }

--- a/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
+++ b/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
@@ -415,7 +415,7 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
 {
     std::vector<StandardCalculatorViewModel ^> viewModels(2);
 
-    // Create 3 instances of StandardCalculatorViewModel in Standard and Scientific mode
+    // Create 2 instances of StandardCalculatorViewModel in Standard mode
     for (int i = 0; i < 2; i++)
     {
         viewModels[i] = ref new StandardCalculatorViewModel();
@@ -429,8 +429,67 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
 
     // Perform Calculations on both the instances and check that the History items work independently
 
-    // Standard Mode: Expression 1+2=
-    TESTITEM standardModeTestItems[2][8] = { { { NumbersAndOperatorsEnum::IsScientificMode, L"0", L"" },
+    TESTITEM standardModeTestItems[2][8] = { { { NumbersAndOperatorsEnum::IsStandardMode, L"0", L"" },
+                                               { NumbersAndOperatorsEnum::Three, L"3", L"" },
+                                               { NumbersAndOperatorsEnum::Add, L"3", L"3 + " },
+                                               { NumbersAndOperatorsEnum::Two, L"2", L"3 + " },
+                                               { NumbersAndOperatorsEnum::Multiply, L"5", L"5 * " },
+                                               { NumbersAndOperatorsEnum::One, L"1", L"5 * " },
+                                               { NumbersAndOperatorsEnum::Equals, L"5", L"" },
+                                               { NumbersAndOperatorsEnum::None, L"", L"" } },
+                                             { { NumbersAndOperatorsEnum::IsStandardMode, L"0", L"" },
+                                               { NumbersAndOperatorsEnum::One, L"1", L"" },
+                                               { NumbersAndOperatorsEnum::Add, L"1", L"1 + " },
+                                               { NumbersAndOperatorsEnum::Two, L"2", L"1 + " },
+                                               { NumbersAndOperatorsEnum::Multiply, L"3", L"3 * " },
+                                               { NumbersAndOperatorsEnum::Three, L"3", L"3 * " },
+                                               { NumbersAndOperatorsEnum::Equals, L"9", L"" },
+                                               { NumbersAndOperatorsEnum::None, L"", L"" } } };
+
+    // Run the commands
+    for (int i = 0; i < 2; i++)
+    {
+        ValidateViewModelByCommands(viewModels[i], standardModeTestItems[i], true);
+    }
+
+    String ^ expression[2][2] = { { L"5   " + UtfUtils::MUL + L"   1 =", L"3   +   2 =" }, { L"3   " + UtfUtils::MUL + L"   3 =", L"1   +   2 =" } };
+    String ^ result[2][2] = { { L"5", L"5" }, { L"9", L"3" } };
+
+    // Assert for the history list items of the instances
+    for (int i = 0; i < 2; i++)
+    {
+        VERIFY_IS_TRUE(2 == viewModels[i]->HistoryVM->ItemsCount);
+
+        for (int j = 0; j < 2 ; j++)
+        {
+            auto item = static_cast<HistoryItemViewModel ^>(viewModels[i]->HistoryVM->Items->GetAt(j));
+
+            VERIFY_ARE_EQUAL(expression[i][j], item->Expression);
+            VERIFY_ARE_EQUAL(result[i][j], item->Result);
+        }
+    }
+}
+
+// Perform calculations on 2 separate instances of Scientific Modes and verify that their History list items are maintained separately
+TEST_METHOD(MultipleScientificModesHistoryAddItemTest)
+{
+    std::vector<StandardCalculatorViewModel ^> viewModels(2);
+
+    // Create 2 instances of StandardCalculatorViewModel in Scientific mode
+    for (int i = 0; i < 2; i++)
+    {
+        viewModels[i] = ref new StandardCalculatorViewModel();
+
+        // Scientific Mode
+        ChangeMode(viewModels[i], 1);
+
+        // Validate that the history items list is initially empty
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemsCount);
+    }
+
+    // Perform Calculations on both the instances and check that the History items work independently
+
+    TESTITEM scientificModeTestItems[2][8] = { { { NumbersAndOperatorsEnum::IsScientificMode, L"0", L"" },
                                                { NumbersAndOperatorsEnum::One, L"1", L"" },
                                                { NumbersAndOperatorsEnum::Add, L"1", L"1 + " },
                                                { NumbersAndOperatorsEnum::Two, L"2", L"1 + " },
@@ -448,67 +507,11 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
     // Run the commands
     for (int i = 0; i < 2; i++)
     {
-        ValidateViewModelByCommands(viewModels[i], standardModeTestItems[i], true);
+        ValidateViewModelByCommands(viewModels[i], scientificModeTestItems[i], true);
     }
 
     String ^ expression[] = { L"1   +   2 =", L"1   +   2   " + UtfUtils::MUL + L"   3 =" };
     String ^ result[] = { L"3", L"7" };
-
-    // Assert for the history list items of the instances
-    for (int i = 0; i < 2; i++)
-    {
-        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemsCount);
-
-        auto item = static_cast<HistoryItemViewModel ^>(viewModels[i]->HistoryVM->Items->GetAt(0));
-
-        VERIFY_ARE_EQUAL(expression[i], item->Expression);
-        VERIFY_ARE_EQUAL(result[i], item->Result);
-    }
-}
-
-// Perform calculations on 2 separate instances of Scientific Modes and verify that their History list items are maintained separately
-TEST_METHOD(MultipleScientificModesHistoryAddItemTest)
-{
-    std::vector<StandardCalculatorViewModel ^> viewModels(2);
-
-    // Create 3 instances of StandardCalculatorViewModel in Standard and Scientific mode
-    for (int i = 0; i < 2; i++)
-    {
-        viewModels[i] = ref new StandardCalculatorViewModel();
-
-        // Scientific Mode
-        ChangeMode(viewModels[i], 1);
-
-        // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemsCount);
-    }
-
-    // Perform Calculations on both the instances and check that the History items work independently
-
-    // Standard Mode: Expression 1+2=
-    TESTITEM standardModeTestItems[2][8] = { { { NumbersAndOperatorsEnum::IsStandardMode, L"0", L"" },
-                                               { NumbersAndOperatorsEnum::One, L"1", L"" },
-                                               { NumbersAndOperatorsEnum::Add, L"1", L"1 + " },
-                                               { NumbersAndOperatorsEnum::Two, L"2", L"1 + " },
-                                               { NumbersAndOperatorsEnum::Equals, L"3", L"" },
-                                               { NumbersAndOperatorsEnum::None, L"", L"" } },
-                                             { { NumbersAndOperatorsEnum::IsStandardMode, L"0", L"" },
-                                               { NumbersAndOperatorsEnum::One, L"1", L"" },
-                                               { NumbersAndOperatorsEnum::Add, L"1", L"1 + " },
-                                               { NumbersAndOperatorsEnum::Two, L"2", L"1 + " },
-                                               { NumbersAndOperatorsEnum::Multiply, L"3", L"1 + 2 * " },
-                                               { NumbersAndOperatorsEnum::Three, L"3", L"1 + 2 * " },
-                                               { NumbersAndOperatorsEnum::Equals, L"9", L"" },
-                                               { NumbersAndOperatorsEnum::None, L"", L"" } } };
-
-    // Run the commands
-    for (int i = 0; i < 2; i++)
-    {
-        ValidateViewModelByCommands(viewModels[i], standardModeTestItems[i], true);
-    }
-
-    String ^ expression[] = { L"1   +   2 =", L"1   +   2   " + UtfUtils::MUL + L"   3 =" };
-    String ^ result[] = { L"3", L"9" };
 
     // Assert for the history list items of the instances
     for (int i = 0; i < 2; i++)


### PR DESCRIPTION
…r (#1453)

(cherry picked from commit 565e3e2714ceb45ae7f2e860a319ea790ab24cef)
Previous PR link: https://github.com/microsoft/calculator/pull/1453

## Migrate calculator master PR to C# calculator branch


### Description of the changes:
- For standard calculator, when processing an input binary operator, if there is a previous operation, this feature completes the equation using that previous operation and add said equation to the history. The new secondary display and the next history entry will start with m_currentVal followed by the new binary operator to better communicate to the user that the calculator is working in immediate execution. These changes have been applied to the CCalcEngine::ProcessCommandWorker method in CalcManager/CEngine/scicomm.cpp.


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Each operator (unary and binary, including negation) has been thoroughly unit tested (using different combinations and orderings of one or more operators and numerical inputs) to ensure proper functionality. These unit tests have been added to CalculatorManagerTest.cpp and HistoryTests.cpp. Existing unit tests that no longer pass due to this change have also been updated.
- The changes have also been manually tested to ensure the UX matches the intended functionality.


