### PR TITLE
Adds unit-test cases for NarratorAnnouncement after fixing issue #138…

### DIFF
--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -242,6 +242,7 @@
     <ClCompile Include="LocalizationSettingsUnitTests.cpp" />
     <ClCompile Include="Mocks\CurrencyHttpClient.cpp" />
     <ClCompile Include="MultiWindowUnitTests.cpp" />
+    <ClCompile Include="NarratorAnnouncementUnitTests.cpp" />
     <ClCompile Include="NavCategoryUnitTests.cpp" />
     <ClCompile Include="RationalTest.cpp" />
     <ClCompile Include="StandardViewModelUnitTests.cpp" />

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
@@ -30,6 +30,7 @@
     <ClCompile Include="LocalizationServiceUnitTests.cpp" />
     <ClCompile Include="RationalTest.cpp" />
     <ClCompile Include="LocalizationSettingsUnitTests.cpp" />
+    <ClCompile Include="NarratorAnnouncementUnitTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DateUtils.h" />

--- a/src/CalculatorUnitTests/NarratorAnnouncementUnitTests.cpp
+++ b/src/CalculatorUnitTests/NarratorAnnouncementUnitTests.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#include "pch.h"
+
+#include <CppUnitTest.h>
+
+
+using namespace Windows::UI::Xaml::Automation::Peers;
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace CalculatorApp::Common::Automation;
+
+
+namespace CalculatorUnitTests
+{
+    TEST_CLASS(NarratorAnnouncementUnitTests)
+    {
+    public:
+        TEST_METHOD(TestGetDisplayUpdatedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetDisplayUpdatedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"DisplayUpdated");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::Other);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetMaxDigitsReachedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetMaxDigitsReachedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"MaxDigitsReached");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::Other);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetMemoryClearedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetMemoryClearedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"MemoryCleared");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ItemRemoved);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetMemoryItemChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetMemoryItemChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"MemorySlotChanged");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::MostRecent);
+        }
+
+        TEST_METHOD(TestGetMemoryItemAddedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetMemoryItemAddedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"MemorySlotAdded");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ItemAdded);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::MostRecent);
+        }
+
+        TEST_METHOD(TestGetHistoryClearedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetHistoryClearedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"HistoryCleared");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ItemRemoved);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::MostRecent);
+        }
+
+        TEST_METHOD(TestGetHistorySlotClearedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetHistorySlotClearedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"HistorySlotCleared");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ItemRemoved);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetCategoryNameChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetCategoryNameChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"CategoryNameChanged");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetUpdateCurrencyRatesAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetUpdateCurrencyRatesAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"UpdateCurrencyRates");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetDisplayCopiedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetDisplayCopiedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"DisplayCopied");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetOpenParenthesisCountChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetOpenParenthesisCountChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"OpenParenthesisCountChanged");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetNoRightParenthesisAddedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetNoRightParenthesisAddedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"NoParenthesisAdded");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetGraphModeChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetGraphModeChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"GraphModeChanged");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetGraphViewChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetGraphViewChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"GraphViewChanged");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::CurrentThenMostRecent);
+        }
+
+        TEST_METHOD(TestGetFunctionRemovedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetFunctionRemovedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"FunctionRemoved");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ItemRemoved);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetGraphViewBestFitChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"GraphViewBestFitChanged");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::MostRecent);
+        }
+
+        TEST_METHOD(TestGetAlwaysOnTopChangedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetAlwaysOnTopChangedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"AlwaysOnTop");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+        TEST_METHOD(TestGetBitShiftRadioButtonCheckedAnnouncement)
+        {
+            auto annoucement = CalculatorAnnouncement::GetBitShiftRadioButtonCheckedAnnouncement(m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->Announcement, m_testAnnouncement);
+            VERIFY_ARE_EQUAL(annoucement->ActivityId, L"BitShiftRadioButtonContent");
+            VERIFY_ARE_EQUAL(annoucement->Kind, AutomationNotificationKind::ActionCompleted);
+            VERIFY_ARE_EQUAL(annoucement->Processing, AutomationNotificationProcessing::ImportantMostRecent);
+        }
+
+    private:
+        static const Platform::StringReference m_testAnnouncement;
+    };
+
+    const Platform::StringReference NarratorAnnouncementUnitTests::m_testAnnouncement(L"TestAnnouncement");
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
…6 (#1469)

(cherry picked from commit 9d8e2ad18c472fb9a511d67cb9430e8a7732552a)
Previous PR link: https://github.com/microsoft/calculator/pull/1469

## Migrate calculator master PR to C# calculator branch
Add unit test cases for NarratorAnnouncement
PR #1465 which fixed issue #1386 has changed a part of NarratorAnnouncement's behaviors. To strengthen the quality of the code, add unit test cases for NarratorAnnouncement.

### Description of the changes:
- Add Test-Class NarratorAnnouncementUnitTests with 18 test methods.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Run CalculatorUnitTests project.
- All newly added test methods succeed.
