### PR TITLE
Resolves a crashing issue occurs around ControlSizeTrigger::~ControlSizeTrigger()

### DIFF
--- a/src/Calculator/Views/StateTriggers/ControlSizeTrigger.cs
+++ b/src/Calculator/Views/StateTriggers/ControlSizeTrigger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -48,21 +48,6 @@ namespace CalculatorApp.Views.StateTriggers
         // Using a DependencyProperty as the backing store for MinWidth.  This enables animation, styling, binding, etc...
         public static readonly DependencyProperty MinWidthProperty =
             DependencyProperty.Register(nameof(MinWidth), typeof(double), typeof(ControlSizeTrigger), new PropertyMetadata(-1));
-
-        ~ControlSizeTrigger()
-        {
-            // CSHARP_MIGRATION: TODO:
-            // finalization will happen on a finalizer's thread.
-            // to prevent crashing the entire app, switch to UI thread to do unregistering work
-            Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
-            {
-                UnregisterSizeChanged(Source);
-            })
-                .AsTask()
-                .ConfigureAwait(false)
-                .GetAwaiter()
-                .GetResult();
-        }
 
         private void OnSourcePropertyChanged(FrameworkElement oldValue, FrameworkElement newValue)
         {


### PR DESCRIPTION
## Fixes a crashing issue occurs around `ControlSizeTrigger::~ControlSizeTrigger()`.


### Description of the changes:
- Remove `ControlSizeTrigger::~ControlSizeTrigger()`

### Explanation:
- The delegates which is refering to `ControlSizeTrigger::OnSizeChanged()` is well managed in C#, so we don't need to manage its lifecycle in this case
- Fixes this issue aligning with the resolution of alarms.app

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build Passed
- Validated with UI tests and manual tests
- CI-Pipeline is not applicable at current stage

