### PR TITLE
remove the strong reference carried from delegate

### DIFF
--- a/src/Calculator/Utils/DelegateCommandUtils.cs
+++ b/src/Calculator/Utils/DelegateCommandUtils.cs
@@ -8,7 +8,7 @@ namespace CalculatorApp.Utils
 {
     static class DelegateCommandUtils
     {
-        public static DelegateCommand MakeDelegateCommand<TTarget>(TTarget target, DelegateCommandHandler handler)
+        public static DelegateCommand MakeDelegateCommand<TTarget>(TTarget target, Action<TTarget, object> handler)
             where TTarget : class
         {
             WeakReference weakTarget = new WeakReference(target);
@@ -17,7 +17,7 @@ namespace CalculatorApp.Utils
                 TTarget thatTarget = weakTarget.Target as TTarget;
                 if(null != thatTarget)
                 {
-                    handler.Invoke(param);
+                    handler.Invoke(thatTarget, param);
                 }
             });
         }

--- a/src/Calculator/Views/Calculator.xaml.cs
+++ b/src/Calculator/Views/Calculator.xaml.cs
@@ -141,7 +141,11 @@ namespace CalculatorApp
             {
                 if (donotuse_HistoryButtonPressed == null)
                 {
-                    donotuse_HistoryButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this, ToggleHistoryFlyout);
+                    donotuse_HistoryButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this,
+                        (that, param) =>
+                        {
+                            that.ToggleHistoryFlyout(param);
+                        });
                 }
                 return donotuse_HistoryButtonPressed;
             }

--- a/src/Calculator/Views/CalculatorScientificAngleButtons.xaml.cs
+++ b/src/Calculator/Views/CalculatorScientificAngleButtons.xaml.cs
@@ -48,7 +48,11 @@ namespace CalculatorApp
             {
                 if (donotuse_ButtonPressed == null)
                 {
-                    donotuse_ButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this, OnAngleButtonPressed);
+                    donotuse_ButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this,
+                        (that, param)=>
+                        {
+                            that.OnAngleButtonPressed(param);
+                        });
                 }
                 return donotuse_ButtonPressed;
             }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cs
@@ -115,7 +115,11 @@ namespace CalculatorApp
             {
                 if (donotuse_ZoomOutButtonPressed == null)
                 {
-                    donotuse_ZoomOutButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this, OnZoomOutCommand);
+                    donotuse_ZoomOutButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this,
+                        (that, param) =>
+                        {
+                            that.OnZoomOutCommand(param);
+                        });
                 }
                 return donotuse_ZoomOutButtonPressed;
             }
@@ -128,7 +132,11 @@ namespace CalculatorApp
             {
                 if (donotuse_ZoomInButtonPressed == null)
                 {
-                    donotuse_ZoomInButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this, OnZoomInCommand);
+                    donotuse_ZoomInButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this,
+                        (that, param) =>
+                        {
+                            that.OnZoomInCommand(param);
+                        });
                 }
                 return donotuse_ZoomInButtonPressed;
             }

--- a/src/Calculator/Views/StateTriggers/CalculatorProgrammerDisplayPanel.xaml.cs
+++ b/src/Calculator/Views/StateTriggers/CalculatorProgrammerDisplayPanel.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Windows.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -17,7 +17,11 @@ namespace CalculatorApp
             {
                 if (donotuse_BitLengthButtonPressed == null)
                 {
-                    donotuse_BitLengthButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this, OnBitLengthButtonPressed);
+                    donotuse_BitLengthButtonPressed = DelegateCommandUtils.MakeDelegateCommand(this,
+                        (that, param) =>
+                        {
+                            that.OnBitLengthButtonPressed(param);
+                        });
                 }
                 return donotuse_BitLengthButtonPressed;
             }


### PR DESCRIPTION
## (DelegateCommand) remove the strong reference carried from delegate.


### Description of the changes:
- Problem: Assigning method name to DelegateCommandHandler will bind a strong reference to a target.
- Fix: using Action<> to decouple the strong reference.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Build passed
- CI-pipeline is not applicable at current stage

