### PR TITLE
Cherry-Pick: Fixed a graphing calculator "permissions" bug caused by PR #1426 (#1471)

### DIFF
--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -92,7 +92,7 @@ namespace CalculatorApp::ViewModel
             const MyVirtualKey virtualKey;
             const wchar_t* const accessKey;
             const bool supportsNegative;
-            const bool isEnabled;
+            bool isEnabled;
         };
 
     private
@@ -139,6 +139,8 @@ namespace CalculatorApp::ViewModel
             static bool IsGraphingCalculatorViewMode(ViewMode mode);
             static bool IsDateCalculatorViewMode(ViewMode mode);
             static bool IsConverterViewMode(ViewMode mode);
+
+            static void InitializeCategoryManifest(Windows::System::User ^ user);
 
             static Platform::String ^ GetFriendlyName(ViewMode mode);
             static Platform::String ^ GetNameResourceKey(ViewMode mode);

--- a/src/Calculator/App.xaml.cs
+++ b/src/Calculator/App.xaml.cs
@@ -86,6 +86,7 @@ namespace CalculatorApp
                 // If the app got pre-launch activated, then save that state in a flag
                 m_preLaunched = true;
             }
+            NavCategory.InitializeCategoryManifest(args.User);
             OnAppLaunch(args, args.Arguments);
         }
 


### PR DESCRIPTION
## Cherry-Pick: Fixed a graphing calculator "permissions" bug caused by PR #1426 (#1471)


### Description of the changes:
>
> - The PR #1426 can cause a crash when no users are returned via `User::FindAllAsync(UserType::LocalUser)` when subsequently trying to access the first user. The existing code also does not guarantee that the returned user is the currently active user.
> - This fix retrieves the user that opened the app and passes this user into a function to check if this user has the proper permissions to access the graphing mode. This makes sense since the active user is indistinguishable (at least from the app's perspective) to the user who opened the app. This user's permissions are then propagated downwards to properly set up the navigation menu of the app.
> - Implementation detail worth pointing out: `s_categoryManifest` is what is used to populate the navigation menu of the app, but this variable is static by design, so a separate function was written to override the appropriate `isEnabled` value in `s_categoryManifest`. This function is called by `onLaunched`.
> - Manual testing


